### PR TITLE
Persist Kotlin daemon process samples

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
@@ -7,6 +7,7 @@ import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.domain.model.ProcessType
 import io.github.cdsap.daemonitor.domain.model.Source
 import io.github.cdsap.daemonitor.store.db.WatcherDb
 import kotlinx.coroutines.CoroutineDispatcher
@@ -75,6 +76,9 @@ class WatcherDatabase private constructor(
         db.watcherQueries.samplesInWindow(pid, startMs, endMs)
             .executeAsList()
             .map { it.rss_memory_mb to it.cpu_percent }
+
+    fun processSampleCount(type: ProcessType): Long =
+        db.watcherQueries.countProcessSamplesByType(type.name).executeAsOne()
 
     /** One-shot snapshot of all retained builds, newest first. Drives the explicit History refresh
      *  the poll loop triggers after inserting builds (reactive `asFlow` notifications proved

--- a/src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq
+++ b/src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq
@@ -52,6 +52,11 @@ SELECT rss_memory_mb, cpu_percent
 FROM process_samples
 WHERE pid = ? AND timestamp >= ? AND timestamp <= ?;
 
+countProcessSamplesByType:
+SELECT COUNT(*)
+FROM process_samples
+WHERE process_type = ?;
+
 insertBuild:
 INSERT OR REPLACE INTO builds(build_id, daemon_pid, daemon_identity, command_line, working_directory, project_path, start_time, end_time, duration_seconds, peak_memory_mb, avg_memory_mb, peak_cpu_percent, inferred_source, final_status, log_snippet, agent, agent_provider)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
@@ -66,6 +66,31 @@ class WatcherDatabaseTest {
     }
 
     @Test
+    fun `kotlin daemon samples are persisted by process type`(@TempDirArg tmp: Path) {
+        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        val p = GradleProcess(
+            pid = 9,
+            parentPid = 1,
+            type = ProcessType.KOTLIN_DAEMON,
+            commandLine = "java org.jetbrains.kotlin.daemon.KotlinCompileDaemon",
+            workingDirectory = "/p",
+            projectPath = "/p",
+            cpuPercent = 12.5,
+            rssMemoryMb = 512,
+            maxHeapMb = 1500,
+            minHeapMb = null,
+            gc = "G1",
+            startTimeMs = 1,
+            status = "RUNNING",
+        )
+
+        db.insertSample(p, timestampMs = 1_000)
+
+        assertEquals(1L, db.processSampleCount(ProcessType.KOTLIN_DAEMON))
+        assertEquals(0L, db.processSampleCount(ProcessType.GRADLE_DAEMON))
+    }
+
+    @Test
     fun `purge removes rows older than retention window`(@TempDirArg tmp: Path) = runTest {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
         val now = 100L * 24 * 60 * 60 * 1000 // day 100


### PR DESCRIPTION
## Summary
- add a typed process-sample count query
- cover persisted Kotlin daemon samples with a regression test

Fixes #3

## Validation
- ./gradlew test