### PR TITLE
Show loading state before first poll

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
@@ -81,7 +81,9 @@ fun LiveMonitorScreen(state: LiveUiState, onSelect: (Long) -> Unit, onClearSelec
 
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         SummaryHeader(state)
-        if (state.isEmpty) {
+        if (state.isLoading) {
+            EmptyState("Scanning for Gradle processes...", modifier = Modifier.weight(1f))
+        } else if (state.isEmpty) {
             EmptyState("No Gradle processes are running right now.", modifier = Modifier.weight(1f))
         } else {
             val concurrent = Badges.concurrentSameProjectPids(state.processes)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveUiState.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveUiState.kt
@@ -28,6 +28,7 @@ data class LiveUiState(
     val summary: LiveSummary = LiveSummary(0, 0, null, 0),
     val detail: DetailState = DetailState.NoSelection,
     val tail: List<String> = emptyList(),
+    val isLoading: Boolean = true,
     val isEmpty: Boolean = true,
 ) {
     /** A process row whose restricted fields (cwd/project) could not be read (KTD-6). */

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModel.kt
@@ -23,6 +23,7 @@ class LiveViewModel {
             summary = summarize(processes),
             detail = detail,
             tail = if (detail is DetailState.Ended) current.tail else tailForSelected,
+            isLoading = false,
             isEmpty = processes.isEmpty(),
         )
     }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
@@ -29,6 +29,15 @@ class LiveMonitorScreenUiTest {
     )
 
     @Test
+    fun `first render shows scanning state before the first poll`() = runComposeUiTest {
+        mainClock.autoAdvance = false
+
+        setContent { WatcherTheme { LiveMonitorScreen(LiveUiState(), onSelect = {}, onClearSelection = {}) } }
+
+        onNodeWithText("Scanning for Gradle processes...").assertExists()
+    }
+
+    @Test
     fun `process table shows the uptime column and the daemon row`() = runComposeUiTest {
         // The screen runs a 1s wall-clock ticker (infinite delay loop); freezing the test clock
         // keeps the composition idle so node queries don't spin.
@@ -37,6 +46,7 @@ class LiveMonitorScreenUiTest {
         val state = LiveUiState(
             processes = listOf(sampleProcess()),
             summary = LiveSummary(activeProcessCount = 1, totalRssMb = 1024, highestMemoryPid = 4321, activeProjectCount = 1),
+            isLoading = false,
             isEmpty = false,
         )
         setContent { WatcherTheme { LiveMonitorScreen(state, onSelect = {}, onClearSelection = {}) } }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
@@ -17,6 +17,17 @@ class LiveViewModelTest {
         )
 
     @Test
+    fun `initial state is loading until first poll completes`() {
+        val vm = LiveViewModel()
+
+        assertTrue(vm.state.value.isLoading)
+
+        vm.onPoll(emptyList())
+
+        assertTrue(!vm.state.value.isLoading)
+    }
+
+    @Test
     fun `poll populates rows and summary`() {
         val vm = LiveViewModel()
         vm.onPoll(listOf(proc(1, rss = 100, project = "/a"), proc(2, rss = 300, project = "/b"), proc(3, rss = 50, project = "/a")))


### PR DESCRIPTION
## Summary
- add an explicit loading state to the live monitor UI model
- render a scanning state before the first process poll completes
- add view model and Compose UI regression coverage

Fixes #5

## Validation
- ./gradlew test