### PR TITLE
Cover app icon assets

### DIFF
--- a/src/test/kotlin/io/github/cdsap/daemonitor/AppIconTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/AppIconTest.kt
@@ -1,0 +1,28 @@
+package io.github.cdsap.daemonitor
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class AppIconTest {
+    @Test
+    fun `runtime app icon is available on the classpath`() {
+        val icon = javaClass.classLoader.getResource("icon/daemonitor.png")
+
+        assertNotNull(icon)
+    }
+
+    @Test
+    fun `native package icons are present for every supported platform`() {
+        listOf(
+            Path.of("icons/daemonitor.icns"),
+            Path.of("icons/daemonitor.ico"),
+            Path.of("icons/daemonitor.png"),
+        ).forEach { icon ->
+            assertTrue(Files.isRegularFile(icon), "$icon should exist")
+            assertTrue(Files.size(icon) > 0L, "$icon should not be empty")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add regression coverage that the runtime app icon is on the classpath
- assert native package icons exist for macOS, Windows, and Linux

Fixes #6

## Validation
- ./gradlew test --tests io.github.cdsap.daemonitor.AppIconTest