### PR TITLE
fix: name the application JVM entry point

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,7 @@ tasks.test {
 
 compose.desktop {
     application {
-        mainClass = "io.github.cdsap.daemonitor.MainKt"
+        mainClass = "io.github.cdsap.daemonitor.Daemonitor"
         nativeDistributions {
             // One format per OS; each is only buildable on its own platform (jpackage limitation).
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -1,3 +1,5 @@
+@file:JvmName("Daemonitor")
+
 package io.github.cdsap.daemonitor
 
 import androidx.compose.foundation.layout.fillMaxSize

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ApplicationEntryPointTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ApplicationEntryPointTest.kt
@@ -1,0 +1,16 @@
+package io.github.cdsap.daemonitor
+
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ApplicationEntryPointTest {
+    @Test
+    fun `application exposes a named static entry point`() {
+        val entryPoint = Class.forName("io.github.cdsap.daemonitor.Daemonitor")
+            .getMethod("main", Array<String>::class.java)
+
+        assertTrue(Modifier.isPublic(entryPoint.modifiers))
+        assertTrue(Modifier.isStatic(entryPoint.modifiers))
+    }
+}


### PR DESCRIPTION
## Summary

JPS now identifies the running desktop application as `Daemonitor` instead of the compiler-generated `MainKt`. The launcher uses an explicit JVM file class name, with regression coverage ensuring the public static entry point remains available.

Fixes #13

## Testing

- `./gradlew test`
- Launched with `./gradlew run` and verified the JVM command ends in `io.github.cdsap.daemonitor.Daemonitor`

## Post-Deploy Monitoring & Validation

- After the next packaged build, launch Daemonitor and inspect `jps -l` or the JVM command line.
- Healthy signal: the entry point is `io.github.cdsap.daemonitor.Daemonitor`.
- Failure signal: `MainKt` reappears or the application fails to launch; revert this PR and restore the previous main class.
- Validation window and owner: first launch of the next release, repository maintainer.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
