### PR TITLE
fix: align history filters with retention presets

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
@@ -24,6 +24,9 @@ object Defaults {
     const val MIN_RETENTION_DAYS: Long = 1
     const val MAX_RETENTION_DAYS: Long = 90
 
+    /** Retention choices shared by Settings and the Historical view filter. */
+    val RETENTION_PRESETS: List<Long> = listOf(7, 15, 30, 60, 90)
+
     /** Memory highlight thresholds, in MiB of RSS (U9). */
     const val MEM_WARN_MB: Long = 4_096
     const val MEM_CRIT_MB: Long = 8_192

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryFilter.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryFilter.kt
@@ -1,28 +1,39 @@
 package io.github.cdsap.daemonitor.ui.history
 
+import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.Build
-import java.time.Instant
-import java.time.ZoneId
 
-/** Time-range presets for the Historical view (U8). MVP: Today / Last 24h / All. */
-enum class TimeRange(val label: String) {
-    ALL("All"),
-    TODAY("Today"),
-    LAST_24H("Last 24 hours");
+/** Rolling time ranges aligned with the history-retention choices in Settings. */
+enum class TimeRange(val days: Long) {
+    LAST_7_DAYS(7),
+    LAST_15_DAYS(15),
+    LAST_30_DAYS(30),
+    LAST_60_DAYS(60),
+    LAST_90_DAYS(90),
+    ;
 
-    /** Inclusive lower bound in epoch-ms, or null for ALL. */
-    fun cutoffMs(nowMs: Long, zone: ZoneId = ZoneId.systemDefault()): Long? = when (this) {
-        ALL -> null
-        LAST_24H -> nowMs - 24L * 60 * 60 * 1000
-        TODAY -> Instant.ofEpochMilli(nowMs).atZone(zone).toLocalDate()
-            .atStartOfDay(zone).toInstant().toEpochMilli()
+    val label: String
+        get() = "$days days"
+
+    fun cutoffMs(nowMs: Long): Long = nowMs - days * DAY_MS
+
+    companion object {
+        private const val DAY_MS = 24L * 60 * 60 * 1000
+
+        init {
+            check(entries.map(TimeRange::days) == Defaults.RETENTION_PRESETS) {
+                "Historical ranges must match the configured retention presets"
+            }
+        }
+
+        val DEFAULT: TimeRange = entries.single { it.days == Defaults.DEFAULT_RETENTION_DAYS }
     }
 }
 
 /** Active filter selection. Filters compound with AND (U8). */
 data class HistoryFilter(
     val projectPath: String? = null,
-    val timeRange: TimeRange = TimeRange.TODAY,
+    val timeRange: TimeRange = TimeRange.DEFAULT,
 )
 
 /** Pure filtering, kept separate from the ViewModel so it is deterministically testable (U8). */

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -24,8 +24,6 @@ import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.ui.common.SectionCard
 import io.github.cdsap.daemonitor.ui.common.Space
 
-private val RETENTION_PRESETS = listOf(7L, 15L, 30L, 60L, 90L)
-
 @Composable
 fun SettingsScreen(state: SettingsUiState, onRetentionDays: (Long) -> Unit) {
     Column(
@@ -56,7 +54,7 @@ fun SettingsScreen(state: SettingsUiState, onRetentionDays: (Long) -> Unit) {
                 )
                 Spacer(Modifier.height(Space.md))
                 Row(horizontalArrangement = Arrangement.spacedBy(Space.sm)) {
-                    RETENTION_PRESETS.forEach { days ->
+                    Defaults.RETENTION_PRESETS.forEach { days ->
                         FilterChip(
                             selected = state.retentionDays == days,
                             onClick = { onRetentionDays(days) },

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
@@ -48,4 +48,17 @@ class HistoryScreenUiTest {
         setContent { WatcherTheme { HistoryScreen(state, onProject = {}, onTimeRange = {}) } }
         onNodeWithText("No builds match the current filters.").assertExists()
     }
+
+    @Test
+    fun `time filters show the retention presets`() = runComposeUiTest {
+        val state = HistoryUiState(builds = listOf(sampleBuild()), isEmptyResult = false)
+        setContent { WatcherTheme { HistoryScreen(state, onProject = {}, onTimeRange = {}) } }
+
+        listOf(7, 15, 30, 60, 90).forEach { days ->
+            onNodeWithText("$days days").assertExists()
+        }
+        onNodeWithText("All").assertDoesNotExist()
+        onNodeWithText("Today").assertDoesNotExist()
+        onNodeWithText("Last 24 hours").assertDoesNotExist()
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryViewModelTest.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor.ui.history
 
+import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.Source
@@ -25,41 +26,48 @@ class HistoryViewModelTest {
     @Test
     fun `project filter narrows to selected project`() {
         val vm = vm()
-        vm.setTimeRange(TimeRange.ALL)
         vm.onBuilds(listOf(build("a", now, "/x"), build("b", now, "/y"), build("c", now, "/x")))
         vm.setProject("/x")
         assertEquals(listOf("a", "c"), vm.state.value.builds.map { it.buildId })
     }
 
     @Test
-    fun `today preset excludes yesterday's build`() {
+    fun `time-range presets match retention choices and use rolling day cutoffs`() {
+        assertEquals(Defaults.RETENTION_PRESETS, TimeRange.entries.map(TimeRange::days))
+        assertEquals(Defaults.DEFAULT_RETENTION_DAYS, TimeRange.DEFAULT.days)
+        TimeRange.entries.forEach { range ->
+            assertEquals(now - range.days * dayMs, range.cutoffMs(now))
+        }
+    }
+
+    @Test
+    fun `seven-day preset excludes an older build`() {
         val vm = vm()
-        vm.setTimeRange(TimeRange.TODAY)
-        val yesterday = now - dayMs - 1000
-        vm.onBuilds(listOf(build("old", yesterday, "/x"), build("today", now, "/x")))
-        assertEquals(listOf("today"), vm.state.value.builds.map { it.buildId })
+        vm.setTimeRange(TimeRange.LAST_7_DAYS)
+        val olderThanSevenDays = now - 7 * dayMs - 1
+        vm.onBuilds(listOf(build("old", olderThanSevenDays, "/x"), build("recent", now, "/x")))
+        assertEquals(listOf("recent"), vm.state.value.builds.map { it.buildId })
     }
 
     @Test
     fun `project and time-range compound with AND`() {
         val vm = vm()
-        vm.setTimeRange(TimeRange.TODAY)
-        val yesterday = now - dayMs - 1000
+        vm.setTimeRange(TimeRange.LAST_7_DAYS)
+        val old = now - 7 * dayMs - 1
         vm.onBuilds(
             listOf(
-                build("x-today", now, "/x"),
-                build("y-today", now, "/y"),
-                build("x-old", yesterday, "/x"),
+                build("x-recent", now, "/x"),
+                build("y-recent", now, "/y"),
+                build("x-old", old, "/x"),
             ),
         )
         vm.setProject("/x")
-        assertEquals(listOf("x-today"), vm.state.value.builds.map { it.buildId })
+        assertEquals(listOf("x-recent"), vm.state.value.builds.map { it.buildId })
     }
 
     @Test
     fun `no matching builds sets empty-result flag`() {
         val vm = vm()
-        vm.setTimeRange(TimeRange.ALL)
         vm.onBuilds(listOf(build("a", now, "/x")))
         vm.setProject("/nonexistent")
         assertTrue(vm.state.value.isEmptyResult)


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#18: Align Historical Data filter with retention policiy options

Fixes #18

## Verification

- `./gradlew test`

## Automation

Detected by the two-hour Hermes assigned-issue monitor. This PR is ready for human review and is not configured for automatic merge.