### PR TITLE
fix: use main logo icon in top left section in the ui

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor.ui.common
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -27,9 +28,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.github.cdsap.daemonitor.BuildInfo
 
 /** Top-level navigation: Live Monitor and Historical tabs (U7). Resolves the navigation-model gap. */
@@ -73,7 +74,11 @@ private fun AppHeader(buildInfo: BuildInfo) {
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(Space.sm),
     ) {
-        Text("◢◤", color = MaterialTheme.colorScheme.primary, fontWeight = FontWeight.Bold, fontSize = 16.sp)
+        Image(
+            painter = painterResource("icon/daemonitor.png"),
+            contentDescription = "Daemonitor logo",
+            modifier = Modifier.size(32.dp),
+        )
         Text(
             "Daemonitor",
             style = MaterialTheme.typography.titleMedium,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.daemonitor.ui.common
 
 import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.BuildInfo
@@ -9,6 +10,21 @@ import kotlin.test.Test
 
 @OptIn(ExperimentalTestApi::class)
 class AppScaffoldUiTest {
+    @Test
+    fun `header shows the Daemonitor logo`() = runComposeUiTest {
+        setContent {
+            WatcherTheme {
+                AppScaffold(
+                    liveContent = { Text("Live") },
+                    historyContent = { Text("History") },
+                    settingsContent = { Text("Settings") },
+                )
+            }
+        }
+
+        onNodeWithContentDescription("Daemonitor logo").assertExists()
+    }
+
     @Test
     fun `header shows application version and commit`() = runComposeUiTest {
         setContent {


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#17: Use main logo icon in top left section in the UI

Fixes #17

## Verification

- `./gradlew test`

## Automation

Detected by the two-hour Hermes assigned-issue monitor. This PR is ready for human review and is not configured for automatic merge.