### PR TITLE
feat: add headless collection mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ Source builds require **JDK 21** because the Kotlin build is pinned to a Java 21
 ./gradlew run
 ```
 
+To collect and persist data without starting Compose or requiring a display server:
+
+```bash
+./gradlew runHeadless
+```
+
+Packaged launchers also accept `--headless`. Headless and desktop modes use the same local database
+and retention setting. Stop the collector with `Ctrl+C` or the service manager's normal termination
+signal.
+
 ## Build a native distribution
 
 The Compose Gradle plugin packages a platform-native installer via `jpackage` (must be built on the

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,13 @@ tasks.test {
     useJUnitPlatform()
 }
 
+tasks.register<JavaExec>("runHeadless") {
+    group = "application"
+    description = "Runs Daemonitor without the desktop UI"
+    mainClass.set("io.github.cdsap.daemonitor.DaemonitorHeadless")
+    classpath = sourceSets.main.get().runtimeClasspath
+}
+
 compose.desktop {
     application {
         mainClass = "io.github.cdsap.daemonitor.Daemonitor"

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -1,0 +1,73 @@
+@file:JvmName("DaemonitorHeadless")
+
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.store.SettingsStore
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+import java.io.PrintStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+internal object HeadlessLauncher {
+    fun run(
+        args: Array<String>,
+        output: PrintStream = System.out,
+        error: PrintStream = System.err,
+    ): Int {
+        if (args.any { it == "--help" || it == "-h" }) {
+            output.println("Usage: daemonitor --headless")
+            return 0
+        }
+        if (args.isNotEmpty()) {
+            error.println("Unknown headless option: ${args.first()}")
+            return 2
+        }
+
+        val database = WatcherDatabase.open()
+        val runtime = WatcherRuntime.create(database)
+        val retentionDays = SettingsStore().load().retentionDays
+        val pollingThread = Thread.currentThread()
+        val cleanupFinished = CountDownLatch(1)
+        val shutdownHook = Thread({
+            pollingThread.interrupt()
+            cleanupFinished.await(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }, "daemonitor-headless-shutdown")
+
+        return try {
+            database.purgeOlderThan(System.currentTimeMillis(), retentionDays)
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
+            output.println("Daemonitor headless collector started")
+            runBlocking {
+                while (currentCoroutineContext().isActive) {
+                    runCatching { runtime.pollOnce() }
+                        .onFailure { error.println("Daemonitor poll failed: ${it.message}") }
+                    delay(Defaults.POLL_INTERVAL)
+                }
+            }
+            0
+        } catch (_: InterruptedException) {
+            0
+        } catch (_: CancellationException) {
+            0
+        } finally {
+            try {
+                database.close()
+            } finally {
+                cleanupFinished.countDown()
+                runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
+            }
+        }
+    }
+
+    private const val SHUTDOWN_TIMEOUT_SECONDS = 5L
+}
+
+fun main(args: Array<String>) {
+    val exitCode = HeadlessLauncher.run(args)
+    if (exitCode != 0) kotlin.system.exitProcess(exitCode)
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -27,7 +27,16 @@ import io.github.cdsap.daemonitor.ui.settings.SettingsScreen
  * Application entry point (U1 scaffold, wired in U7). Opens the database, starts the polling
  * [WatcherService], and renders the tabbed UI. The Historical tab is wired in U8.
  */
-fun main() = application {
+fun main(args: Array<String>) {
+    if (args.firstOrNull() == "--headless") {
+        val exitCode = HeadlessLauncher.run(args.drop(1).toTypedArray())
+        if (exitCode != 0) kotlin.system.exitProcess(exitCode)
+        return
+    }
+    launchDesktop()
+}
+
+private fun launchDesktop() = application {
     val service = remember { WatcherService.create() }
     val windowState = rememberWindowState(
         size = DpSize(1180.dp, 760.dp),

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -1,0 +1,75 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.collect.DaemonLog
+import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
+import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.domain.BuildAggregator
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+
+/** UI-independent collection and persistence runtime shared by desktop and headless launchers. */
+class WatcherRuntime(
+    private val collector: ProcessCollector = ProcessCollector(),
+    private val logWatcher: DaemonLogWatcher = DaemonLogWatcher(),
+    private val aggregator: BuildAggregator,
+    private val database: WatcherDatabase,
+    private val clock: () -> Long = System::currentTimeMillis,
+) {
+    private var knownDaemonPids = emptySet<Long>()
+
+    data class PollResult(
+        val processes: List<GradleProcess>,
+        val daemonLogs: List<DaemonLog>,
+        val buildsChanged: Boolean,
+    )
+
+    fun pollOnce(): PollResult {
+        val now = clock()
+        val processes = collector.poll()
+        processes.forEach { database.insertSample(it, now) }
+
+        val logs = logWatcher.discover()
+        return PollResult(
+            processes = processes,
+            daemonLogs = logs,
+            buildsChanged = processForBuilds(logs),
+        )
+    }
+
+    fun tailFor(logs: List<DaemonLog>, pid: Long): List<String> =
+        logs.firstOrNull { it.pid == pid }?.let { logWatcher.tailFor(it.path) }.orEmpty()
+
+    private fun processForBuilds(logs: List<DaemonLog>): Boolean {
+        val currentPids = logs.map { it.pid }.toSet()
+        var inserted = false
+
+        for (log in logs) {
+            val events = logWatcher.readNewEvents(log.path)
+            if (events.isNotEmpty()) {
+                aggregator.onEvents(log.pid, events).forEach {
+                    database.insertBuild(it)
+                    inserted = true
+                }
+            }
+        }
+
+        (knownDaemonPids - currentPids).forEach { gonePid ->
+            aggregator.onDaemonGone(gonePid)?.let {
+                database.insertBuild(it)
+                inserted = true
+            }
+        }
+        knownDaemonPids = currentPids
+        return inserted
+    }
+
+    companion object {
+        fun create(database: WatcherDatabase): WatcherRuntime = WatcherRuntime(
+            aggregator = BuildAggregator(
+                sampleProvider = database::samplesInWindow,
+                ambientEnvNames = System.getenv().keys.toSet(),
+            ),
+            database = database,
+        )
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -1,9 +1,5 @@
 package io.github.cdsap.daemonitor
 
-import io.github.cdsap.daemonitor.collect.DaemonLog
-import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
-import io.github.cdsap.daemonitor.collect.ProcessCollector
-import io.github.cdsap.daemonitor.domain.BuildAggregator
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.ui.history.HistoryViewModel
@@ -17,16 +13,9 @@ import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
-/**
- * Application coordinator (U7 wiring). Runs the periodic poll on [Dispatchers.IO]: collect
- * processes → persist samples; read daemon-log events → aggregate builds → persist; feed the
- * [LiveViewModel]. Build *existence* comes from the log (KTD-1); resource metrics from polling
- * (KTD-2). Heavy I/O stays off the UI thread (Compose best practice).
- */
+/** Desktop adapter that runs [WatcherRuntime] on [Dispatchers.IO] and projects results into UI state. */
 class WatcherService(
-    private val collector: ProcessCollector = ProcessCollector(),
-    private val logWatcher: DaemonLogWatcher = DaemonLogWatcher(),
-    private val aggregator: BuildAggregator,
+    private val runtime: WatcherRuntime,
     private val database: WatcherDatabase,
     private val settingsStore: SettingsStore = SettingsStore(),
     private val clock: () -> Long = System::currentTimeMillis,
@@ -43,8 +32,6 @@ class WatcherService(
     )
 
     private var serviceScope: CoroutineScope? = null
-    private var knownDaemonPids = emptySet<Long>()
-
     fun start(scope: CoroutineScope) {
         serviceScope = scope
         database.purgeOlderThan(clock(), retentionDays)
@@ -85,63 +72,32 @@ class WatcherService(
 
     /** One poll cycle, factored out for testability. */
     suspend fun pollOnce() {
-        val now = clock()
-        val processes = collector.poll()
-        processes.forEach { database.insertSample(it, now) }
-
-        val logs = logWatcher.discover()
-        val insertedBuilds = processForBuilds(logs)
+        val result = runtime.pollOnce()
 
         // Surface the selected daemon's tail, if any is selected.
-        val selectedTail = selectedDaemonTail(logs)
+        val selectedTail = selectedDaemonTail(result)
         withContext(Dispatchers.Main) {
-            liveViewModel.onPoll(processes, selectedTail)
+            liveViewModel.onPoll(result.processes, selectedTail)
         }
 
         // A new build landed → push it to the Historical tab immediately.
-        if (insertedBuilds) refreshHistory()
+        if (result.buildsChanged) refreshHistory()
     }
 
-    /** @return true if at least one build was inserted this cycle (drives the History refresh). */
-    private fun processForBuilds(logs: List<DaemonLog>): Boolean {
-        val currentPids = logs.map { it.pid }.toSet()
-        var inserted = false
-
-        for (log in logs) {
-            val events = logWatcher.readNewEvents(log.path)
-            if (events.isNotEmpty()) {
-                aggregator.onEvents(log.pid, events).forEach { database.insertBuild(it); inserted = true }
-            }
-        }
-
-        // Daemons that vanished since last poll → flush any in-flight build as interrupted.
-        (knownDaemonPids - currentPids).forEach { gonePid ->
-            aggregator.onDaemonGone(gonePid)?.let { database.insertBuild(it); inserted = true }
-        }
-        knownDaemonPids = currentPids
-        return inserted
-    }
-
-    private fun selectedDaemonTail(logs: List<DaemonLog>): List<String> {
+    private fun selectedDaemonTail(result: WatcherRuntime.PollResult): List<String> {
         val detail = liveViewModel.state.value.detail
         val pid = when (detail) {
             is io.github.cdsap.daemonitor.ui.live.DetailState.Selected -> detail.process.pid
             else -> return emptyList()
         }
-        val log = logs.firstOrNull { it.pid == pid } ?: return emptyList()
-        return logWatcher.tailFor(log.path)
+        return runtime.tailFor(result.daemonLogs, pid)
     }
 
     companion object {
         /** Build a fully wired service against the real database. */
         fun create(database: WatcherDatabase = WatcherDatabase.open()): WatcherService =
             WatcherService(
-                aggregator = BuildAggregator(
-                    sampleProvider = database::samplesInWindow,
-                    // The watcher's own env is the ambient baseline: any agent var already present
-                    // here is inherited by every build it observes, so it can't single out a build.
-                    ambientEnvNames = System.getenv().keys.toSet(),
-                ),
+                runtime = WatcherRuntime.create(database),
                 database = database,
             )
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.daemonitor.store
 import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import app.cash.sqldelight.db.SqlDriver
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
@@ -30,8 +31,11 @@ import kotlin.io.path.exists
  */
 class WatcherDatabase private constructor(
     private val db: WatcherDb,
+    private val driver: SqlDriver,
     private val ioDispatcher: CoroutineDispatcher,
-) {
+) : AutoCloseable {
+
+    override fun close() = driver.close()
 
     fun insertSample(p: GradleProcess, timestampMs: Long) {
         db.watcherQueries.insertSample(
@@ -126,7 +130,7 @@ class WatcherDatabase private constructor(
             } else {
                 migrateInPlace(driver)
             }
-            return WatcherDatabase(WatcherDb(driver), ioDispatcher)
+            return WatcherDatabase(WatcherDb(driver), driver, ioDispatcher)
         }
 
         /** Add columns introduced after a DB was first created. SQLite has no ADD COLUMN IF NOT

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ApplicationEntryPointTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ApplicationEntryPointTest.kt
@@ -13,4 +13,13 @@ class ApplicationEntryPointTest {
         assertTrue(Modifier.isPublic(entryPoint.modifiers))
         assertTrue(Modifier.isStatic(entryPoint.modifiers))
     }
+
+    @Test
+    fun `headless mode exposes a named static entry point`() {
+        val entryPoint = Class.forName("io.github.cdsap.daemonitor.DaemonitorHeadless")
+            .getMethod("main", Array<String>::class.java)
+
+        assertTrue(Modifier.isPublic(entryPoint.modifiers))
+        assertTrue(Modifier.isStatic(entryPoint.modifiers))
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessLauncherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessLauncherTest.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.daemonitor
+
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HeadlessLauncherTest {
+    @Test
+    fun `help prints usage without starting the collector`() {
+        val output = ByteArrayOutputStream()
+
+        val exitCode = HeadlessLauncher.run(arrayOf("--help"), output = PrintStream(output))
+
+        assertEquals(0, exitCode)
+        assertTrue(output.toString().contains("daemonitor --headless"))
+    }
+
+    @Test
+    fun `unknown option returns usage error without starting the collector`() {
+        val error = ByteArrayOutputStream()
+
+        val exitCode = HeadlessLauncher.run(arrayOf("--unknown"), error = PrintStream(error))
+
+        assertEquals(2, exitCode)
+        assertTrue(error.toString().contains("Unknown headless option: --unknown"))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
@@ -114,6 +114,17 @@ class WatcherDatabaseTest {
             assertTrue(perms.none { it.startsWith("GROUP") || it.startsWith("OTHERS") }, perms.toString())
         }
     }
+
+    @Test
+    fun `closed database releases its driver`(@TempDirArg tmp: Path) {
+        val path = tmp.resolve("watcher.db")
+        val db = WatcherDatabase.open(path)
+
+        db.close()
+        Files.delete(path)
+
+        assertTrue(!path.exists())
+    }
 }
 
 private typealias TempDirArg = org.junit.jupiter.api.io.TempDir


### PR DESCRIPTION
## Summary

Daemonitor can now collect Gradle process and build history on machines without a display server. The packaged launcher accepts `--headless`, while source checkouts can use `./gradlew runHeadless`; both modes share the existing database and retention settings.

Collection and persistence now run through a UI-independent runtime. The desktop adapter continues projecting results into Compose state, while the headless launcher handles termination signals and waits for SQLite cleanup before shutdown.

## Validation

- `./gradlew test`
- `./gradlew runHeadless --args=--help`
- `./gradlew run --args='--headless --help' -Djava.awt.headless=true`
- Started the real collector and terminated it with `Ctrl+C`

## Post-Deploy Monitoring & Validation

- Watch stderr for `Daemonitor poll failed` and confirm startup prints `Daemonitor headless collector started`.
- Confirm `watcher.db` receives current process samples and reconstructed builds during a 15-minute smoke test.
- Treat repeated poll failures, a locked database after termination, or missing new samples as rollback triggers.
- Owner: PR author during initial release validation.
