### PR TITLE
feat: refresh UI with native inspector styling

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
@@ -3,13 +3,16 @@ package io.github.cdsap.daemonitor.ui.common
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
@@ -17,8 +20,10 @@ import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -43,15 +48,7 @@ fun AppScaffold(
 ) {
     var selectedTab by remember { mutableStateOf(0) }
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
-        AppHeader(buildInfo)
-        TabRow(
-            selectedTabIndex = selectedTab,
-            containerColor = MaterialTheme.colorScheme.surface,
-        ) {
-            NavTab("Live Monitor", Icons.Filled.Speed, selectedTab == 0) { selectedTab = 0 }
-            NavTab("Historical", Icons.Filled.History, selectedTab == 1) { selectedTab = 1 }
-            NavTab("Settings", Icons.Filled.Settings, selectedTab == 2) { selectedTab = 2 }
-        }
+        AppHeader(buildInfo, selectedTab) { selectedTab = it }
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         Column(modifier = Modifier.weight(1f)) {
             when (selectedTab) {
@@ -64,51 +61,72 @@ fun AppScaffold(
 }
 
 /** A slim brand bar so the window reads as a product, not a bare tab strip. */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AppHeader(buildInfo: BuildInfo) {
-    Row(
+private fun AppHeader(buildInfo: BuildInfo, selectedTab: Int, onSelectTab: (Int) -> Unit) {
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
-            .padding(horizontal = Space.lg, vertical = Space.md),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(Space.sm),
+            .height(56.dp),
     ) {
-        Image(
-            painter = painterResource("icon/daemonitor.png"),
-            contentDescription = "Daemonitor logo",
-            modifier = Modifier.size(32.dp),
-        )
-        Text(
-            "Daemonitor",
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.SemiBold,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-        Text(
-            "live build & daemon insight",
-            style = MaterialTheme.typography.labelMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
-        Spacer(modifier = Modifier.weight(1f))
-        Text(
-            "v${buildInfo.version} · ${buildInfo.commit}",
-            style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        val compact = maxWidth < 760.dp
+        Row(
+            modifier = Modifier.fillMaxSize().padding(horizontal = Space.lg),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(Space.sm),
+        ) {
+            Image(
+                painter = painterResource("icon/daemonitor.png"),
+                contentDescription = "Daemonitor logo",
+                modifier = Modifier.size(28.dp),
+            )
+            Text(
+                "Daemonitor",
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+            Spacer(modifier = Modifier.width(Space.lg))
+            SingleChoiceSegmentedButtonRow {
+                NAV_ITEMS.forEachIndexed { index, item ->
+                    SegmentedButton(
+                        selected = selectedTab == index,
+                        onClick = { onSelectTab(index) },
+                        shape = SegmentedButtonDefaults.itemShape(index, NAV_ITEMS.size),
+                        icon = {},
+                        label = {
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
+                                Icon(item.icon, contentDescription = null, modifier = Modifier.size(15.dp))
+                                Text(item.label)
+                            }
+                        },
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.weight(1f))
+            if (!compact) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
+                    androidx.compose.foundation.layout.Box(
+                        modifier = Modifier.size(7.dp).background(Accent.success, androidx.compose.foundation.shape.CircleShape),
+                    )
+                    Text("LOCAL", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+                }
+                Spacer(modifier = Modifier.width(Space.md))
+                Text(
+                    "v${buildInfo.version} · ${buildInfo.commit}",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
     }
 }
 
-@Composable
-private fun NavTab(label: String, icon: ImageVector, selected: Boolean, onClick: () -> Unit) {
-    Tab(
-        selected = selected,
-        onClick = onClick,
-        text = {
-            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
-                Icon(icon, contentDescription = null, modifier = Modifier.size(18.dp))
-                Text(label, fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal)
-            }
-        },
-    )
-}
+private data class NavItem(val label: String, val icon: ImageVector)
+
+private val NAV_ITEMS = listOf(
+    NavItem("Live", Icons.Filled.Speed),
+    NavItem("History", Icons.Filled.History),
+    NavItem("Settings", Icons.Filled.Settings),
+)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Badges.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Badges.kt
@@ -1,16 +1,7 @@
 package io.github.cdsap.daemonitor.ui.common
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
@@ -60,47 +51,20 @@ object Badges {
 
 @Composable
 fun MemoryBadge(level: BadgeLevel, modifier: Modifier = Modifier) {
-    val (bg, label) = when (level) {
-        BadgeLevel.WARN -> Color(0xFFB26A00) to "HIGH MEM"
-        BadgeLevel.CRITICAL -> Color(0xFFB00020) to "CRIT MEM"
+    val (fg, bg, label) = when (level) {
+        BadgeLevel.WARN -> Triple(Accent.warn, Accent.warnBg, "HIGH MEM")
+        BadgeLevel.CRITICAL -> Triple(Accent.danger, Accent.dangerBg, "CRIT MEM")
     }
-    Text(
-        text = label,
-        color = Color.White,
-        fontSize = 10.sp,
-        modifier = modifier
-            .clip(RoundedCornerShape(4.dp))
-            .background(bg)
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-        style = MaterialTheme.typography.labelSmall,
-    )
+    Pill(label, fg, bg, modifier)
 }
 
 @Composable
 fun ConcurrentBadge(modifier: Modifier = Modifier) {
-    Text(
-        text = "MULTI-BUILD",
-        color = Color.White,
-        fontSize = 10.sp,
-        modifier = modifier
-            .clip(RoundedCornerShape(4.dp))
-            .background(Color(0xFF5E35B1))
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-        style = MaterialTheme.typography.labelSmall,
-    )
+    Pill("MULTI-BUILD", Accent.info, Accent.infoBg, modifier)
 }
 
 /** Marks an invocation run with `--non-interactive` / `--console=plain` (likely CI/script/agent). */
 @Composable
 fun AutomatedBadge(modifier: Modifier = Modifier) {
-    Text(
-        text = "AUTOMATED",
-        color = Color.White,
-        fontSize = 10.sp,
-        modifier = modifier
-            .clip(RoundedCornerShape(4.dp))
-            .background(Color(0xFF00796B))
-            .padding(horizontal = 6.dp, vertical = 2.dp),
-        style = MaterialTheme.typography.labelSmall,
-    )
+    Pill("AUTOMATED", Accent.brand, Accent.brandBg, modifier)
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Components.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Components.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.daemonitor.ui.common
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -37,17 +39,17 @@ fun StatTile(
     val tint = accent ?: MaterialTheme.colorScheme.primary
     Surface(
         modifier = modifier,
-        shape = RoundedCornerShape(Radius.md),
+        shape = RoundedCornerShape(Radius.sm),
         color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 2.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Row(modifier = Modifier.height(IntrinsicSize.Min)) {
             // Slim accent rail on the leading edge gives each tile a quiet pop of color.
-            Box(modifier = Modifier.width(3.dp).fillMaxHeight().background(tint.copy(alpha = 0.85f)))
+            Box(modifier = Modifier.width(2.dp).fillMaxHeight().background(tint))
             Column(modifier = Modifier.padding(Space.md)) {
                 Row(verticalAlignment = Alignment.CenterVertically) {
                     if (icon != null) {
-                        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(14.dp))
+                        Icon(icon, contentDescription = null, tint = tint, modifier = Modifier.size(13.dp))
                         Spacer(Modifier.width(Space.xs))
                     }
                     Text(
@@ -57,7 +59,7 @@ fun StatTile(
                     )
                 }
                 Spacer(Modifier.height(Space.xs))
-                Text(value, style = MaterialTheme.typography.headlineSmall, fontWeight = FontWeight.SemiBold)
+                Text(value, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.SemiBold)
             }
         }
     }
@@ -70,17 +72,34 @@ fun SectionCard(title: String, modifier: Modifier = Modifier, content: @Composab
         modifier = modifier,
         shape = RoundedCornerShape(Radius.md),
         color = MaterialTheme.colorScheme.surface,
-        tonalElevation = 1.dp,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
-        Column(modifier = Modifier.padding(Space.md)) {
-            Text(
-                title.uppercase(),
-                style = MaterialTheme.typography.labelMedium,
-                fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.fillMaxWidth().padding(bottom = Space.sm),
-            )
-            Box(modifier = Modifier.weight(1f).fillMaxWidth()) { content() }
+        Column {
+            Row(
+                modifier = Modifier.fillMaxWidth().height(38.dp).background(MaterialTheme.colorScheme.surfaceVariant).padding(horizontal = Space.md),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(title, style = MaterialTheme.typography.labelMedium, fontWeight = FontWeight.SemiBold)
+            }
+            androidx.compose.material3.HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Box(modifier = Modifier.weight(1f).fillMaxWidth().padding(Space.md)) { content() }
         }
+    }
+}
+
+/** Compact screen toolbar used above data-heavy desktop views. */
+@Composable
+fun ScreenHeader(
+    title: String,
+    modifier: Modifier = Modifier,
+    trailing: @Composable () -> Unit = {},
+) {
+    Row(
+        modifier = modifier.fillMaxWidth().height(48.dp).padding(horizontal = Space.lg),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+        trailing()
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Pills.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Pills.kt
@@ -41,7 +41,7 @@ fun Pill(
 ) {
     Row(
         modifier = modifier
-            .clip(RoundedCornerShape(Radius.pill))
+            .clip(RoundedCornerShape(Radius.sm))
             .background(bg)
             .padding(horizontal = 8.dp, vertical = 2.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/PrivacyNotice.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/PrivacyNotice.kt
@@ -29,8 +29,8 @@ fun PrivacyNotice(modifier: Modifier = Modifier) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(MaterialTheme.colorScheme.surfaceVariant)
-                .padding(horizontal = Space.md, vertical = 6.dp),
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(horizontal = Space.lg, vertical = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(Space.xs),
         ) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Tables.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Tables.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 
 /** A table column: a header label, a flex weight, and whether its cells are end-aligned (numbers). */
 data class Col(val label: String, val weight: Float, val end: Boolean = false)
@@ -23,7 +24,7 @@ data class Col(val label: String, val weight: Float, val end: Boolean = false)
 fun TableHeader(cols: List<Col>) {
     Surface(color = MaterialTheme.colorScheme.surfaceVariant) {
         Row(
-            modifier = Modifier.fillMaxWidth().padding(horizontal = Space.md, vertical = Space.sm),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = Space.md, vertical = 7.dp),
             horizontalArrangement = Arrangement.spacedBy(Space.sm),
         ) {
             cols.forEach { c ->

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Theme.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Theme.kt
@@ -5,7 +5,11 @@ import androidx.compose.material3.Typography
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 
 /** Single 4-pt spacing scale so every screen uses the same rhythm (removes the "scattered" feel). */
 object Space {
@@ -18,10 +22,9 @@ object Space {
 
 /** Shared corner radii so cards, tiles, and pills feel like one family. */
 object Radius {
-    val pill = 999.dp
-    val sm = 8.dp
-    val md = 12.dp
-    val lg = 16.dp
+    val sm = 4.dp
+    val md = 6.dp
+    val lg = 8.dp
 }
 
 /**
@@ -46,26 +49,36 @@ object Accent {
 }
 
 private val WatcherColors = lightColorScheme(
-    primary = Color(0xFF00695C),          // teal 800 — Gradle-adjacent accent
+    primary = Color(0xFF28735F),
     onPrimary = Color.White,
-    primaryContainer = Color(0xFFD9EEEA),
-    onPrimaryContainer = Color(0xFF00382F),
-    secondary = Color(0xFF455A64),        // blue-grey 700
+    primaryContainer = Color(0xFFDCECE6),
+    onPrimaryContainer = Color(0xFF143E33),
+    secondary = Color(0xFF4D5A66),
     surface = Color(0xFFFFFFFF),
-    onSurface = Color(0xFF18211F),
-    surfaceVariant = Color(0xFFEDF1F0),   // header/zebra background
-    onSurfaceVariant = Color(0xFF49544F),
-    outline = Color(0xFFC4CDC9),
-    outlineVariant = Color(0xFFDDE3E1),
-    background = Color(0xFFF4F7F6),
-    error = Color(0xFFB3261E),
+    onSurface = Color(0xFF202522),
+    surfaceVariant = Color(0xFFF1F3F2),
+    onSurfaceVariant = Color(0xFF626A66),
+    outline = Color(0xFFBCC3BF),
+    outlineVariant = Color(0xFFDADFDA),
+    background = Color(0xFFF6F7F7),
+    error = Color(0xFFB23A35),
+)
+
+private val WatcherTypography = Typography(
+    headlineSmall = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 22.sp, lineHeight = 28.sp, fontWeight = FontWeight.SemiBold),
+    titleLarge = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 18.sp, lineHeight = 24.sp, fontWeight = FontWeight.SemiBold),
+    titleMedium = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 14.sp, lineHeight = 20.sp, fontWeight = FontWeight.SemiBold),
+    bodyMedium = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 13.sp, lineHeight = 19.sp),
+    bodySmall = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 12.sp, lineHeight = 17.sp),
+    labelMedium = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 11.sp, lineHeight = 15.sp, fontWeight = FontWeight.Medium),
+    labelSmall = TextStyle(fontFamily = FontFamily.SansSerif, fontSize = 10.sp, lineHeight = 14.sp, fontWeight = FontWeight.Medium),
 )
 
 @Composable
 fun WatcherTheme(content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = WatcherColors,
-        typography = Typography(),
+        typography = WatcherTypography,
         content = content,
     )
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreen.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.daemonitor.ui.history
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -20,6 +21,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -44,7 +46,9 @@ import io.github.cdsap.daemonitor.ui.common.ProcessTypeIcon
 import io.github.cdsap.daemonitor.ui.common.EmptyState
 import io.github.cdsap.daemonitor.ui.common.LogView
 import io.github.cdsap.daemonitor.ui.common.PrivacyNotice
+import io.github.cdsap.daemonitor.ui.common.Radius
 import io.github.cdsap.daemonitor.ui.common.SectionCard
+import io.github.cdsap.daemonitor.ui.common.ScreenHeader
 import io.github.cdsap.daemonitor.ui.common.Space
 import io.github.cdsap.daemonitor.ui.common.SourcePill
 import io.github.cdsap.daemonitor.ui.common.StatusPill
@@ -75,9 +79,9 @@ fun HistoryScreen(state: HistoryUiState, onProject: (String?) -> Unit, onTimeRan
             Row(modifier = Modifier.weight(1f).padding(start = Space.lg, end = Space.lg, bottom = Space.lg)) {
                 Surface(
                     modifier = Modifier.weight(1.5f).fillMaxSize(),
-                    shape = RoundedCornerShape(Space.md),
+                    shape = RoundedCornerShape(Radius.md),
                     color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 1.dp,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                 ) {
                     Column {
                         TableHeader(COLS)
@@ -101,19 +105,30 @@ fun HistoryScreen(state: HistoryUiState, onProject: (String?) -> Unit, onTimeRan
 
 @Composable
 private fun Filters(state: HistoryUiState, onProject: (String?) -> Unit, onTimeRange: (TimeRange) -> Unit) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(Space.lg),
-        horizontalArrangement = Arrangement.spacedBy(Space.sm),
-    ) {
-        TimeRange.entries.forEach { range ->
-            FilterChip(
-                selected = state.filter.timeRange == range,
-                onClick = { onTimeRange(range) },
-                label = { Text(range.label) },
-            )
+    Column {
+        ScreenHeader("Build history")
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = Space.lg, end = Space.lg, bottom = Space.md),
+            horizontalArrangement = Arrangement.spacedBy(Space.sm),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text("RANGE", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            TimeRange.entries.forEach { range ->
+                FilterChip(
+                    selected = state.filter.timeRange == range,
+                    onClick = { onTimeRange(range) },
+                    label = { Text(range.label) },
+                    shape = RoundedCornerShape(Radius.sm),
+                    colors = FilterChipDefaults.filterChipColors(
+                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                    ),
+                )
+            }
+            Spacer(Modifier.width(Space.sm))
+            Text("PROJECT", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            ProjectDropdown(state.projects, state.filter.projectPath, onProject)
         }
-        Spacer(Modifier.width(Space.sm))
-        ProjectDropdown(state.projects, state.filter.projectPath, onProject)
     }
 }
 
@@ -123,6 +138,7 @@ private fun ProjectDropdown(projects: List<String>, selected: String?, onProject
     AssistChip(
         onClick = { expanded = true },
         label = { Text(selected?.substringAfterLast('/')?.let { "Project: $it" } ?: "All projects") },
+        shape = RoundedCornerShape(Radius.sm),
     )
     DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
         DropdownMenuItem(text = { Text("All projects") }, onClick = { onProject(null); expanded = false })
@@ -134,13 +150,13 @@ private fun ProjectDropdown(projects: List<String>, selected: String?, onProject
 
 @Composable
 private fun BuildRow(b: Build, selected: Boolean, onSelect: () -> Unit) {
-    val bg = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.10f) else MaterialTheme.colorScheme.surface
+    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f) else MaterialTheme.colorScheme.surface
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(bg)
             .clickable { onSelect() }
-            .padding(horizontal = Space.md, vertical = Space.sm),
+            .padding(horizontal = Space.md, vertical = 7.dp),
         horizontalArrangement = Arrangement.spacedBy(Space.sm),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.daemonitor.ui.live
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -46,8 +48,10 @@ import io.github.cdsap.daemonitor.ui.common.EmptyState
 import io.github.cdsap.daemonitor.ui.common.LogView
 import io.github.cdsap.daemonitor.ui.common.MemoryBadge
 import io.github.cdsap.daemonitor.ui.common.PrivacyNotice
+import io.github.cdsap.daemonitor.ui.common.Radius
 import io.github.cdsap.daemonitor.ui.common.ProcessTypeIcon
 import io.github.cdsap.daemonitor.ui.common.SectionCard
+import io.github.cdsap.daemonitor.ui.common.ScreenHeader
 import io.github.cdsap.daemonitor.ui.common.Space
 import io.github.cdsap.daemonitor.ui.common.StatTile
 import io.github.cdsap.daemonitor.ui.common.TableHeader
@@ -90,9 +94,9 @@ fun LiveMonitorScreen(state: LiveUiState, onSelect: (Long) -> Unit, onClearSelec
             Row(modifier = Modifier.weight(1f).padding(Space.lg)) {
                 Surface(
                     modifier = Modifier.weight(1.6f).fillMaxSize(),
-                    shape = RoundedCornerShape(Space.md),
+                    shape = RoundedCornerShape(Radius.md),
                     color = MaterialTheme.colorScheme.surface,
-                    tonalElevation = 1.dp,
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
                 ) {
                     Column {
                         TableHeader(COLS)
@@ -118,14 +122,24 @@ fun LiveMonitorScreen(state: LiveUiState, onSelect: (Long) -> Unit, onClearSelec
 
 @Composable
 private fun SummaryHeader(state: LiveUiState) {
-    Row(
-        modifier = Modifier.fillMaxWidth().padding(Space.lg),
-        horizontalArrangement = Arrangement.spacedBy(Space.md),
-    ) {
-        StatTile("Active processes", state.summary.activeProcessCount.toString(), Modifier.weight(1f), icon = Icons.Filled.Memory)
-        StatTile("Total RSS", "${state.summary.totalRssMb} MB", Modifier.weight(1f), icon = Icons.Filled.Storage, accent = Accent.info)
-        StatTile("Highest-mem PID", state.summary.highestMemoryPid?.toString() ?: "—", Modifier.weight(1f), icon = Icons.Filled.TrendingUp, accent = Accent.warn)
-        StatTile("Active projects", state.summary.activeProjectCount.toString(), Modifier.weight(1f), icon = Icons.Filled.FolderOpen, accent = Accent.brand)
+    Column {
+        ScreenHeader("Process monitor") {
+            Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
+                androidx.compose.foundation.layout.Box(
+                    modifier = Modifier.size(7.dp).background(Accent.success, androidx.compose.foundation.shape.CircleShape),
+                )
+                Text("MONITORING", style = MaterialTheme.typography.labelSmall, color = Accent.success)
+            }
+        }
+        Row(
+            modifier = Modifier.fillMaxWidth().padding(start = Space.lg, end = Space.lg, bottom = Space.md),
+            horizontalArrangement = Arrangement.spacedBy(Space.sm),
+        ) {
+            StatTile("Processes", state.summary.activeProcessCount.toString(), Modifier.weight(1f), icon = Icons.Filled.Memory)
+            StatTile("Resident memory", "${state.summary.totalRssMb} MB", Modifier.weight(1f), icon = Icons.Filled.Storage, accent = Accent.info)
+            StatTile("Peak memory PID", state.summary.highestMemoryPid?.toString() ?: "—", Modifier.weight(1f), icon = Icons.Filled.TrendingUp, accent = Accent.warn)
+            StatTile("Projects", state.summary.activeProjectCount.toString(), Modifier.weight(1f), icon = Icons.Filled.FolderOpen, accent = Accent.brand)
+        }
     }
 }
 
@@ -138,13 +152,13 @@ private fun ProcessRow(
     isDegraded: (GradleProcess) -> Boolean,
     onSelect: (Long) -> Unit,
 ) {
-    val bg = if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.10f) else MaterialTheme.colorScheme.surface
+    val bg = if (selected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f) else MaterialTheme.colorScheme.surface
     Row(
         modifier = Modifier
             .fillMaxWidth()
             .background(bg)
             .clickable { onSelect(p.pid) }
-            .padding(horizontal = Space.md, vertical = Space.sm),
+            .padding(horizontal = Space.md, vertical = 7.dp),
         horizontalArrangement = Arrangement.spacedBy(Space.sm),
         verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
     ) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -22,6 +22,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.ui.common.SectionCard
+import io.github.cdsap.daemonitor.ui.common.ScreenHeader
+import io.github.cdsap.daemonitor.ui.common.Radius
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FilterChipDefaults
 import io.github.cdsap.daemonitor.ui.common.Space
 
 @Composable
@@ -29,11 +33,13 @@ fun SettingsScreen(state: SettingsUiState, onRetentionDays: (Long) -> Unit) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
-            .padding(Space.lg),
-        verticalArrangement = Arrangement.spacedBy(Space.lg),
+            .background(MaterialTheme.colorScheme.background),
     ) {
-        SectionCard("History retention", modifier = Modifier.fillMaxWidth().height(184.dp)) {
+        ScreenHeader("Settings")
+        SectionCard(
+            "History retention",
+            modifier = Modifier.fillMaxWidth().height(190.dp).padding(horizontal = Space.lg),
+        ) {
             Column {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
                     Icon(Icons.Filled.History, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
@@ -59,6 +65,11 @@ fun SettingsScreen(state: SettingsUiState, onRetentionDays: (Long) -> Unit) {
                             selected = state.retentionDays == days,
                             onClick = { onRetentionDays(days) },
                             label = { Text("$days days") },
+                            shape = RoundedCornerShape(Radius.sm),
+                            colors = FilterChipDefaults.filterChipColors(
+                                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                            ),
                         )
                     }
                 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.Text
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.BuildInfo
 import kotlin.test.Test
@@ -39,5 +40,24 @@ class AppScaffoldUiTest {
         }
 
         onNodeWithText("v1.2.3 · abc1234").assertExists()
+    }
+
+    @Test
+    fun `segmented navigation switches between application screens`() = runComposeUiTest {
+        setContent {
+            WatcherTheme {
+                AppScaffold(
+                    liveContent = { Text("Live content") },
+                    historyContent = { Text("History content") },
+                    settingsContent = { Text("Settings content") },
+                )
+            }
+        }
+
+        onNodeWithText("Live content").assertExists()
+        onNodeWithText("History").performClick()
+        onNodeWithText("History content").assertExists()
+        onNodeWithText("Settings").performClick()
+        onNodeWithText("Settings content").assertExists()
     }
 }


### PR DESCRIPTION
## Summary

Daemonitor now reads as a focused desktop monitoring tool instead of a default Material dashboard. Live processes, build history, and settings use a compact Native Inspector style with segmented title-bar navigation, denser tables, flatter metrics, quieter status tags, and clearer detail panes.

The refresh preserves the existing workflows and information hierarchy. Secondary title-bar metadata collapses at narrower widths so navigation remains usable without overlap.

## Validation

- `./gradlew test`
- Added coverage for switching all screens through the segmented navigation
- Launched the production desktop entry point and verified startup and interaction
- macOS denied terminal screen-capture permission, so no screenshot artifact is attached

## Post-Deploy Monitoring & Validation

- Validate Live, History, and Settings at the default window size and below 760 px width.
- Confirm navigation remains clickable, table columns remain aligned, and labels do not clip or overlap.
- Roll back if the title bar crowds, a screen becomes unreachable, or selected rows/status tags lose readable contrast.
- Validation window: first release smoke test; owner: PR author.
