### PR TITLE
ci: archive smoke-tested native packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            package_task: packageDeb
+            package_glob: build/compose/binaries/main/deb/*.deb
+            launcher: build/compose/binaries/main/app/Daemonitor/bin/Daemonitor
+          - os: windows-latest
+            platform: windows
+            package_task: packageMsi
+            package_glob: build/compose/binaries/main/msi/*.msi
+            launcher: build/compose/binaries/main/app/Daemonitor/Daemonitor.exe
+          - os: macos-latest
+            platform: macos
+            package_task: packageDmg
+            package_glob: build/compose/binaries/main/dmg/*.dmg
+            launcher: build/compose/binaries/main/app/Daemonitor.app/Contents/MacOS/Daemonitor
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -44,6 +59,40 @@ jobs:
       - name: Run tests (macOS / Windows)
         if: runner.os != 'Linux'
         run: ./gradlew test --no-daemon --stacktrace
+
+      - name: Build native application and installer
+        run: ./gradlew createDistributable ${{ matrix.package_task }} --no-daemon --stacktrace
+
+      - name: Smoke test packaged launcher
+        run: |
+          output=$("${{ matrix.launcher }}" --headless --help)
+          printf '%s\n' "$output"
+          [[ "$output" == *"Usage: daemonitor --headless"* ]]
+
+      - name: Read package version
+        id: package-version
+        run: echo "value=$(./gradlew -q printNativePackageVersion --no-daemon)" >> "$GITHUB_OUTPUT"
+
+      - name: Verify native installer
+        run: |
+          shopt -s nullglob
+          packages=(${{ matrix.package_glob }})
+          if (( ${#packages[@]} != 1 )); then
+            echo "Expected one native installer, found ${#packages[@]}" >&2
+            exit 1
+          fi
+          test -s "${packages[0]}"
+          echo "### Native package" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Platform: ${{ matrix.platform }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Package: ${packages[0]}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload native installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: Daemonitor-${{ steps.package-version.outputs.value }}-${{ matrix.platform }}-${{ github.sha }}
+          path: ${{ matrix.package_glob }}
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload test report
         if: always()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,8 @@ plugins {
 group = "io.github.cdsap.daemonitor"
 version = "0.1.0"
 
+val nativePackageVersion = "1.0.0"
+
 val buildInfoDirectory = layout.buildDirectory.dir("generated/build-info")
 val buildCommit = providers.environmentVariable("GITHUB_SHA")
     .map { it.take(8) }
@@ -89,6 +91,11 @@ tasks.test {
     useJUnitPlatform()
 }
 
+tasks.register("printNativePackageVersion") {
+    description = "Prints the native installer version for CI artifact naming"
+    doLast { println(nativePackageVersion) }
+}
+
 tasks.register<JavaExec>("runHeadless") {
     group = "application"
     description = "Runs Daemonitor without the desktop UI"
@@ -103,7 +110,7 @@ compose.desktop {
             // One format per OS; each is only buildable on its own platform (jpackage limitation).
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Daemonitor"
-            packageVersion = "1.0.0"
+            packageVersion = nativePackageVersion
 
             // Per-platform installer/app icons (jpackage requires the native format per OS).
             macOS { iconFile.set(project.file("icons/daemonitor.icns")) }


### PR DESCRIPTION
## Summary

Successful CI runs now produce downloadable, platform-native Daemonitor installers instead of only test reports. Each runner builds its packaged application, executes the bundled launcher in headless mode as a smoke test, verifies exactly one non-empty installer, and archives it with version, platform, and commit identity.

The smoke test exercises the runtime image that users receive without requiring GUI automation or installation of unsigned packages. Workflow summaries expose the generated package path, and artifacts are retained for 14 days.

Closes #27.

## Validation

- `./gradlew test --no-daemon`
- `./gradlew packageDmg --no-daemon --stacktrace`
- Executed the packaged macOS launcher with `--headless --help`
- Verified `Daemonitor-1.0.0.dmg` exists and is non-empty
- Parsed `.github/workflows/ci.yml` as YAML

Linux and Windows launcher/package paths are validated by this PR's OS matrix.

## Post-Deploy Monitoring & Validation

- Confirm all three CI matrix jobs pass and upload one native installer each.
- Download the `.deb`, `.msi`, and `.dmg` artifacts and verify their package types and non-zero sizes.
- Treat a missing artifact, failed packaged-launcher smoke test, or incorrectly named package as a merge blocker.
- Validation window: this PR run and the first `main` run after merge; owner: PR author.
