### PR TITLE
fix: desktop poll failures are silent while the ui still reports monitor

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -9,6 +9,7 @@ import io.github.cdsap.daemonitor.ui.live.LiveViewModel
 import io.github.cdsap.daemonitor.ui.settings.SettingsUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsViewModel
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
@@ -21,6 +22,7 @@ class WatcherService(
     private val database: WatcherDatabase,
     private val settingsStore: SettingsStore = SettingsStore(),
     private val clock: () -> Long = System::currentTimeMillis,
+    private val pollAction: suspend () -> WatcherRuntime.PollResult = { runtime.pollOnce() },
 ) {
     val liveViewModel = LiveViewModel()
     val historyViewModel = HistoryViewModel()
@@ -43,7 +45,7 @@ class WatcherService(
         scope.launch(Dispatchers.IO) { refreshHistory() }
         scope.launch(Dispatchers.IO) {
             while (isActive) {
-                runCatching { pollOnce() }
+                pollSafely()
                 delay(Defaults.POLL_INTERVAL)
             }
         }
@@ -89,7 +91,7 @@ class WatcherService(
 
     /** One poll cycle, factored out for testability. */
     suspend fun pollOnce() {
-        val result = runtime.pollOnce()
+        val result = pollAction()
 
         // Surface the selected daemon's tail, if any is selected.
         val selectedTail = selectedDaemonTail(result)
@@ -99,6 +101,20 @@ class WatcherService(
 
         // A new build landed → push it to the Historical tab immediately.
         if (result.buildsChanged) refreshHistory()
+    }
+
+    /** Run one retryable desktop poll and expose only a non-sensitive failure classification. */
+    internal suspend fun pollSafely() {
+        try {
+            pollOnce()
+        } catch (error: CancellationException) {
+            throw error
+        } catch (error: Exception) {
+            val errorType = error::class.simpleName ?: "UnknownError"
+            withContext(Dispatchers.Main) {
+                liveViewModel.onPollFailure(clock(), errorType)
+            }
+        }
     }
 
     private fun selectedDaemonTail(result: WatcherRuntime.PollResult): List<String> {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreen.kt
@@ -127,11 +127,17 @@ fun LiveMonitorScreen(state: LiveUiState, onSelect: (Long) -> Unit, onClearSelec
 private fun SummaryHeader(state: LiveUiState) {
     Column {
         ScreenHeader("Process monitor") {
+            val degraded = state.pollError != null
+            val statusColor = if (degraded) LocalAccentColors.current.warn else LocalAccentColors.current.success
             Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
                 androidx.compose.foundation.layout.Box(
-                    modifier = Modifier.size(7.dp).background(LocalAccentColors.current.success, androidx.compose.foundation.shape.CircleShape),
+                    modifier = Modifier.size(7.dp).background(statusColor, androidx.compose.foundation.shape.CircleShape),
                 )
-                Text("MONITORING", style = MaterialTheme.typography.labelSmall, color = LocalAccentColors.current.success)
+                Text(
+                    if (degraded) "DEGRADED" else "MONITORING",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = statusColor,
+                )
             }
         }
         Row(

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveUiState.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveUiState.kt
@@ -22,6 +22,13 @@ data class LiveSummary(
     val activeProjectCount: Int,
 )
 
+/** Safe poll diagnostic. Exception messages are deliberately excluded because they may contain
+ * command lines, paths, or daemon-log content. */
+data class PollError(
+    val failedAtMs: Long,
+    val errorType: String,
+)
+
 /** Full immutable state the Live Monitor renders. */
 data class LiveUiState(
     val processes: List<GradleProcess> = emptyList(),
@@ -30,6 +37,7 @@ data class LiveUiState(
     val tail: List<String> = emptyList(),
     val isLoading: Boolean = true,
     val isEmpty: Boolean = true,
+    val pollError: PollError? = null,
 ) {
     /** A process row whose restricted fields (cwd/project) could not be read (KTD-6). */
     fun isPermissionDegraded(p: GradleProcess): Boolean = p.workingDirectory == null

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModel.kt
@@ -25,7 +25,13 @@ class LiveViewModel {
             tail = if (detail is DetailState.Ended) current.tail else tailForSelected,
             isLoading = false,
             isEmpty = processes.isEmpty(),
+            pollError = null,
         )
+    }
+
+    /** Mark the current data stale while retaining the last successful snapshot. */
+    fun onPollFailure(failedAtMs: Long, errorType: String) {
+        _state.value = _state.value.copy(pollError = PollError(failedAtMs, errorType))
     }
 
     fun select(pid: Long) {

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -1,0 +1,101 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.store.SettingsStore
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class WatcherServiceTest {
+    @Test
+    fun `failed poll records sanitized error and failure timestamp`(@TempDir tmp: Path) = runTest {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            val service = service(database, tmp, clock = { 100 }) {
+                error("secret command line and log content")
+            }
+
+            service.pollSafely()
+
+            val error = service.liveViewModel.state.value.pollError
+            assertEquals(100, error?.failedAtMs)
+            assertEquals("IllegalStateException", error?.errorType)
+            assertFalse(error.toString().contains("secret"))
+        } finally {
+            Dispatchers.resetMain()
+            database.close()
+        }
+    }
+
+    @Test
+    fun `repeated failure replaces the latest failure timestamp`(@TempDir tmp: Path) = runTest {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            var now = 100L
+            var firstFailure = true
+            val service = service(database, tmp, clock = { now }) {
+                if (firstFailure) throw IllegalArgumentException("first failure")
+                error("second failure")
+            }
+
+            service.pollSafely()
+            firstFailure = false
+            now = 200
+            service.pollSafely()
+
+            val error = service.liveViewModel.state.value.pollError
+            assertEquals(200, error?.failedAtMs)
+            assertEquals("IllegalStateException", error?.errorType)
+        } finally {
+            Dispatchers.resetMain()
+            database.close()
+        }
+    }
+
+    @Test
+    fun `successful retry clears the previous failure`(@TempDir tmp: Path) = runTest {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            var fail = true
+            val service = service(database, tmp) {
+                if (fail) error("failure")
+                WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
+            }
+
+            service.pollSafely()
+            fail = false
+            service.pollSafely()
+
+            assertNull(service.liveViewModel.state.value.pollError)
+        } finally {
+            Dispatchers.resetMain()
+            database.close()
+        }
+    }
+
+    private fun service(
+        database: WatcherDatabase,
+        tmp: Path,
+        clock: () -> Long = { 0 },
+        pollAction: suspend () -> WatcherRuntime.PollResult,
+    ) = WatcherService(
+        runtime = WatcherRuntime.create(database),
+        database = database,
+        settingsStore = SettingsStore(tmp.resolve("settings.properties")),
+        clock = clock,
+        pollAction = pollAction,
+    )
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
@@ -51,6 +51,20 @@ class LiveMonitorScreenUiTest {
     }
 
     @Test
+    fun `poll failure replaces monitoring status with degraded indicator`() = runComposeUiTest {
+        mainClock.autoAdvance = false
+        val state = LiveUiState(
+            isLoading = false,
+            pollError = PollError(failedAtMs = 1234, errorType = "IOException"),
+        )
+
+        setContent { WatcherTheme { LiveMonitorScreen(state, onSelect = {}, onClearSelection = {}) } }
+
+        onNodeWithText("DEGRADED").assertExists()
+        onNodeWithText("MONITORING").assertDoesNotExist()
+    }
+
+    @Test
     fun `process table shows the uptime column and the daemon row`() = runComposeUiTest {
         // The screen runs a 1s wall-clock ticker (infinite delay loop); freezing the test clock
         // keeps the composition idle so node queries don't spin.

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
@@ -4,6 +4,7 @@ import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class LiveViewModelTest {
@@ -67,5 +68,28 @@ class LiveViewModelTest {
         vm.onPoll(listOf(proc(1, cwd = null, project = null)))
         val s = vm.state.value
         assertTrue(s.isPermissionDegraded(s.processes.single()))
+    }
+
+    @Test
+    fun `poll failure records a safe diagnostic and timestamp without discarding stale data`() {
+        val vm = LiveViewModel()
+        vm.onPoll(listOf(proc(1)))
+
+        vm.onPollFailure(failedAtMs = 1234, errorType = "IllegalStateException")
+
+        val state = vm.state.value
+        assertEquals(listOf(1L), state.processes.map { it.pid })
+        assertEquals(1234, state.pollError?.failedAtMs)
+        assertEquals("IllegalStateException", state.pollError?.errorType)
+    }
+
+    @Test
+    fun `successful poll clears the latest poll failure`() {
+        val vm = LiveViewModel()
+        vm.onPollFailure(failedAtMs = 1234, errorType = "IOException")
+
+        vm.onPoll(emptyList())
+
+        assertNull(vm.state.value.pollError)
     }
 }


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#36: Desktop poll failures are silent while the UI still reports MONITORING

Fixes #36

## Verification

- `./gradlew test`