### PR TITLE
fix: historical build log excerpts are never captured

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
@@ -16,6 +16,10 @@ object Defaults {
     /** Number of daemon-log lines retained for the live tail. */
     const val LOG_TAIL_LINES: Int = 100
 
+    /** Maximum persisted build-log excerpt, independently bounded by lines and characters. */
+    const val LOG_SNIPPET_LINES: Int = 100
+    const val LOG_SNIPPET_CHARS: Int = 16_000
+
     /** Default history retention window, in days; user-configurable via Settings (KTD-5). Rows
      *  older than the configured window are purged on startup and whenever the setting changes. */
     const val DEFAULT_RETENTION_DAYS: Long = 15

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -44,9 +44,9 @@ class WatcherRuntime(
         var inserted = false
 
         for (log in logs) {
-            val events = logWatcher.readNewEvents(log.path)
-            if (events.isNotEmpty()) {
-                aggregator.onEvents(log.pid, events).forEach {
+            val lines = logWatcher.readNewLines(log.path)
+            if (lines.isNotEmpty()) {
+                lines.flatMap { aggregator.onLogLine(log.pid, it.text, it.event) }.forEach {
                     database.insertBuild(it)
                     inserted = true
                 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/collect/DaemonLogWatcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/collect/DaemonLogWatcher.kt
@@ -13,6 +13,9 @@ import kotlin.io.path.name
 /** A discovered daemon log file with its PID and originating Gradle version. */
 data class DaemonLog(val pid: Long, val gradleVersion: String, val path: Path)
 
+/** One complete, redacted daemon-log line and the build event parsed from that same line. */
+data class DaemonLogLine(val text: String, val event: BuildEvent?)
+
 /**
  * Locates daemon logs, reads new content incrementally (offset-based, cheaper than re-tailing),
  * and parses build events (U3). Redaction (KTD-7) runs on every line before it enters the tail
@@ -48,7 +51,14 @@ class DaemonLogWatcher(
      * Read whatever has been appended to [path] since the last call, returning the parsed events.
      * Lines are redacted before parsing and before being retained for the live tail.
      */
-    fun readNewEvents(path: Path): List<BuildEvent> {
+    fun readNewEvents(path: Path): List<BuildEvent> =
+        readNewLines(path).mapNotNull { it.event }
+
+    /**
+     * Read newly appended complete lines while retaining their parsed-event association. This lets
+     * downstream build correlation assign each redacted line to the exact busy-to-idle window.
+     */
+    fun readNewLines(path: Path): List<DaemonLogLine> {
         if (!path.exists()) return emptyList()
         val size = Files.size(path)
         val from = offsets[path] ?: 0L
@@ -86,7 +96,7 @@ class DaemonLogWatcher(
             .toList()
 
         retainTail(path, redacted)
-        return DaemonLogParser.parse(redacted.asSequence())
+        return redacted.map { DaemonLogLine(it, DaemonLogParser.parseLine(it)) }
     }
 
     /** The last [tailLines] redacted lines seen for a log, for the live tail panel (U7). */

--- a/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor.domain
 
+import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
@@ -32,10 +33,22 @@ class BuildAggregator(
     private val daemons = mutableMapOf<Long, DaemonState>()
 
     fun onEvents(daemonPid: Long, events: List<BuildEvent>): List<Build> {
+        return events.flatMap { processLogLine(daemonPid, line = null, event = it) }
+    }
+
+    /** Correlate one redacted log line with its event while preserving window boundaries. */
+    fun onLogLine(daemonPid: Long, line: String, event: BuildEvent?): List<Build> =
+        processLogLine(daemonPid, line, event)
+
+    private fun processLogLine(daemonPid: Long, line: String?, event: BuildEvent?): List<Build> {
         val state = daemons.getOrPut(daemonPid) { DaemonState() }
         val emitted = mutableListOf<Build>()
 
-        for (event in events) {
+        // A busy marker belongs to the window it opens. Every other line belongs to the currently
+        // open window, including the idle marker that closes it.
+        if (event !is BusyMark) state.window?.let { window -> line?.let(window::appendLogLine) }
+
+        if (event != null) {
             when (event) {
                 is DaemonContextEvent -> event.uid?.let { state.uid = it }
 
@@ -46,6 +59,7 @@ class BuildAggregator(
                         emitted += w.toBuild(daemonPid, state.uid, endMs = event.timestampMs, sampleProvider, ambientEnvNames)
                     }
                     state.window = Window(busyTimeMs = event.timestampMs)
+                    line?.let { state.window?.appendLogLine(it) }
                 }
 
                 is BuildStart -> state.window?.let { w ->
@@ -95,6 +109,19 @@ class BuildAggregator(
         var outcomeSuccess: Boolean? = null,
         var outcomeDurationSeconds: Double? = null,
     ) {
+        private val logLines = ArrayDeque<String>()
+        private var logChars = 0
+
+        fun appendLogLine(line: String) {
+            val boundedLine = line.takeLast(Defaults.LOG_SNIPPET_CHARS)
+            logLines.addLast(boundedLine)
+            logChars += boundedLine.length + if (logLines.size > 1) 1 else 0
+            while (logLines.size > Defaults.LOG_SNIPPET_LINES || logChars > Defaults.LOG_SNIPPET_CHARS) {
+                val removed = logLines.removeFirst()
+                logChars -= removed.length + if (logLines.isNotEmpty()) 1 else 0
+            }
+        }
+
         fun toBuild(
             daemonPid: Long,
             uid: String?,
@@ -132,7 +159,7 @@ class BuildAggregator(
                 peakCpuPercent = cpu.maxOrNull(),
                 inferredSource = SourceDetector.detect(envNames),
                 finalStatus = status,
-                logSnippet = null, // wired with a redacted snippet when the watcher supplies one
+                logSnippet = logLines.takeIf { it.isNotEmpty() }?.joinToString("\n"),
                 agent = agentAttr?.agent,
                 agentProvider = agentAttr?.provider,
             )

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
@@ -1,0 +1,59 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
+import io.github.cdsap.daemonitor.domain.BuildAggregator
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class WatcherRuntimeTest {
+
+    @Test
+    fun `appended daemon log window is redacted and persisted with its build`(
+        @org.junit.jupiter.api.io.TempDir tmp: Path,
+    ) {
+        val versionDir = tmp.resolve("gradle/daemon/8.14.3").also { it.createDirectories() }
+        val log = versionDir.resolve("daemon-75597.out.log")
+        log.writeText("outside before window -Ptoken=before-secret\n")
+
+        WatcherDatabase.open(tmp.resolve("watcher.db")).use { database ->
+            val runtime = WatcherRuntime(
+                logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle")),
+                aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
+                database = database,
+            )
+
+            runtime.pollOnce() // Establish the incremental-read offset.
+            Files.writeString(
+                log,
+                buildString {
+                    appendLine("2026-06-24T10:00:00.000-0700 [INFO] [daemon] Marking the daemon as busy, address: []")
+                    appendLine("2026-06-24T10:00:00.010-0700 [INFO] [daemon] Daemon is about to start building Build{id=build-35, currentDir=/project}")
+                    appendLine("executing with -Ptoken=window-secret")
+                    appendLine("BUILD SUCCESSFUL in 1s")
+                    appendLine("2026-06-24T10:00:01.000-0700 [INFO] [daemon] Marking the daemon as idle, address: []")
+                    appendLine("outside after window")
+                },
+                StandardOpenOption.APPEND,
+            )
+
+            assertTrue(runtime.pollOnce().buildsChanged)
+
+            val build = database.recentBuilds().single()
+            val snippet = assertNotNull(build.logSnippet)
+            assertTrue(snippet.contains("-Ptoken=***"))
+            assertFalse(snippet.contains("window-secret"))
+            assertFalse(snippet.contains("outside before window"))
+            assertFalse(snippet.contains("outside after window"))
+            assertEquals(5, snippet.lines().size)
+        }
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor.domain
 
+import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
 import io.github.cdsap.daemonitor.domain.model.BuildStart
@@ -80,6 +81,23 @@ class BuildAggregatorTest {
         agg.onEvents(pid, listOf(context(0), BusyMark(1_000), start(1_010)))
         val b = agg.onDaemonGone(pid)
         assertEquals(FinalStatus.INTERRUPTED, b!!.finalStatus)
+    }
+
+    @Test
+    fun `interrupted build retains its bounded in-window log excerpt`() {
+        val agg = BuildAggregator()
+        agg.onLogLine(pid, "busy", BusyMark(1_000))
+        agg.onLogLine(pid, "start", start(1_010))
+        repeat(Defaults.LOG_SNIPPET_LINES + 5) { index ->
+            agg.onLogLine(pid, "line-$index-${"x".repeat(200)}", null)
+        }
+
+        val b = agg.onDaemonGone(pid)!!
+        val snippet = b.logSnippet!!
+        assertEquals(FinalStatus.INTERRUPTED, b.finalStatus)
+        assertTrue(snippet.lines().size <= Defaults.LOG_SNIPPET_LINES)
+        assertTrue(snippet.length <= Defaults.LOG_SNIPPET_CHARS)
+        assertTrue(snippet.contains("line-${Defaults.LOG_SNIPPET_LINES + 4}"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#35: Historical build log excerpts are never captured

Fixes #35

## Verification

- `./gradlew test`