### PR TITLE
fix: live monitor counts daemon infrastructure directories as projects

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/collect/ProcessSnapshotBuilder.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/collect/ProcessSnapshotBuilder.kt
@@ -4,6 +4,7 @@ import io.github.cdsap.daemonitor.domain.Redactor
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.PriorSample
 import io.github.cdsap.daemonitor.domain.model.ProcessInfo
+import io.github.cdsap.daemonitor.domain.model.ProcessType
 
 /**
  * Pure, OS-independent construction of a [GradleProcess] snapshot from a [ProcessInfo] plus the
@@ -33,7 +34,9 @@ object ProcessSnapshotBuilder {
             type = type,
             commandLine = Redactor.redactCommandLine(info.commandLine),
             workingDirectory = cwd,
-            projectPath = cwd,
+            // Wrapper processes execute in the requested build directory. Daemon and worker
+            // working directories are runtime infrastructure and do not identify a project.
+            projectPath = cwd.takeIf { type == ProcessType.GRADLE_WRAPPER },
             cpuPercent = computeCpuPercent(info, prior, sampleWallClockMs, logicalProcessorCount),
             rssMemoryMb = info.rssBytes / (1024 * 1024),
             maxHeapMb = jvm.maxHeapMb,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/collect/ProcessSnapshotBuilderTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/collect/ProcessSnapshotBuilderTest.kt
@@ -22,6 +22,8 @@ private class FakeProcess(
 
 private const val DAEMON_CL =
     "java -Xmx4g -XX:+UseG1GC org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.14.3"
+private const val WRAPPER_CL = "java org.gradle.wrapper.GradleWrapperMain test"
+private const val KOTLIN_DAEMON_CL = "java org.jetbrains.kotlin.daemon.KotlinCompileDaemon"
 
 class ProcessSnapshotBuilderTest {
 
@@ -34,11 +36,60 @@ class ProcessSnapshotBuilderTest {
     }
 
     @Test
-    fun `builds snapshot with rss in mb and parsed heap`() {
+    fun `builds daemon snapshot with rss in mb and parsed heap`() {
         val snap = ProcessSnapshotBuilder.build(FakeProcess(commandLine = DAEMON_CL), null, 2_000, 8)!!
         assertEquals(512L, snap.rssMemoryMb)
         assertEquals(4096L, snap.maxHeapMb)
+    }
+
+    @Test
+    fun `gradle daemon working directory is not attributed as a project`() {
+        val snap = ProcessSnapshotBuilder.build(
+            FakeProcess(commandLine = DAEMON_CL, workingDirectory = "/Users/dev/.gradle/daemon/8.14.3"),
+            null,
+            2_000,
+            8,
+        )!!
+
+        assertEquals("/Users/dev/.gradle/daemon/8.14.3", snap.workingDirectory)
+        assertNull(snap.projectPath)
+    }
+
+    @Test
+    fun `kotlin daemon working directory is not attributed as a project`() {
+        val snap = ProcessSnapshotBuilder.build(
+            FakeProcess(commandLine = KOTLIN_DAEMON_CL, workingDirectory = "/Users/dev/.kotlin/daemon"),
+            null,
+            2_000,
+            8,
+        )!!
+
+        assertEquals("/Users/dev/.kotlin/daemon", snap.workingDirectory)
+        assertNull(snap.projectPath)
+    }
+
+    @Test
+    fun `gradle wrapper working directory is attributed as its project`() {
+        val snap = ProcessSnapshotBuilder.build(
+            FakeProcess(commandLine = WRAPPER_CL, workingDirectory = "/Users/dev/proj"),
+            null,
+            2_000,
+            8,
+        )!!
+
         assertEquals("/Users/dev/proj", snap.projectPath)
+    }
+
+    @Test
+    fun `gradle-related process without a project-specific signal has unknown project`() {
+        val snap = ProcessSnapshotBuilder.build(
+            FakeProcess(commandLine = "java worker.org.gradle.process.internal.worker.GradleWorkerMain"),
+            null,
+            2_000,
+            8,
+        )!!
+
+        assertNull(snap.projectPath)
     }
 
     @Test
@@ -59,7 +110,7 @@ class ProcessSnapshotBuilderTest {
     @Test
     fun `empty working directory becomes null project path`() {
         val snap = ProcessSnapshotBuilder.build(
-            FakeProcess(commandLine = DAEMON_CL, workingDirectory = ""), null, 2_000, 8,
+            FakeProcess(commandLine = WRAPPER_CL, workingDirectory = ""), null, 2_000, 8,
         )!!
         assertNull(snap.projectPath)
         assertNull(snap.workingDirectory)

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModelTest.kt
@@ -40,6 +40,20 @@ class LiveViewModelTest {
     }
 
     @Test
+    fun `summary excludes processes without project attribution`() {
+        val vm = LiveViewModel()
+        vm.onPoll(
+            listOf(
+                proc(1, project = "/project"),
+                proc(2, project = null, cwd = "/Users/dev/.gradle/daemon/8.14.3"),
+                proc(3, project = null, cwd = "/Users/dev/.kotlin/daemon"),
+            ),
+        )
+
+        assertEquals(1, vm.state.value.summary.activeProjectCount)
+    }
+
+    @Test
     fun `selecting then disappearing transitions to ended`() {
         val vm = LiveViewModel()
         vm.onPoll(listOf(proc(1), proc(2)))


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#34: Live Monitor counts daemon infrastructure directories as projects

Fixes #34

## Verification

- `./gradlew test`