### PR TITLE
feat: add toolbar switch to headless mode

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
@@ -1,0 +1,50 @@
+package io.github.cdsap.daemonitor
+
+import java.io.File
+
+internal object HeadlessModeSwitcher {
+    fun launch(): Process {
+        val command = currentProcessCommand()
+        val builder = ProcessBuilder(command)
+            .directory(File(System.getProperty("user.dir")))
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+        return builder.start()
+    }
+
+    internal fun commandForCurrentProcess(
+        executable: String?,
+        javaHome: String,
+        classpath: String,
+    ): List<String> {
+        if (executable != null && !executable.isJavaExecutable()) {
+            return listOf(executable, "--headless")
+        }
+
+        val javaExecutable = File(File(javaHome, "bin"), javaExecutableName()).absolutePath
+        return listOf(
+            javaExecutable,
+            "-cp",
+            classpath,
+            "io.github.cdsap.daemonitor.Daemonitor",
+            "--headless",
+        )
+    }
+
+    private fun currentProcessCommand(): List<String> {
+        val info = ProcessHandle.current().info()
+        return commandForCurrentProcess(
+            executable = info.command().orElse(null),
+            javaHome = System.getProperty("java.home"),
+            classpath = System.getProperty("java.class.path"),
+        )
+    }
+
+    private fun String.isJavaExecutable(): Boolean {
+        val name = File(this).name.lowercase()
+        return name == "java" || name == "java.exe"
+    }
+
+    private fun javaExecutableName(): String =
+        if (System.getProperty("os.name").lowercase().contains("windows")) "java.exe" else "java"
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
@@ -16,12 +16,13 @@ internal object HeadlessModeSwitcher {
         executable: String?,
         javaHome: String,
         classpath: String,
+        osName: String = System.getProperty("os.name"),
     ): List<String> {
         if (executable != null && !executable.isJavaExecutable()) {
             return listOf(executable, "--headless")
         }
 
-        val javaExecutable = File(File(javaHome, "bin"), javaExecutableName()).absolutePath
+        val javaExecutable = javaExecutablePath(javaHome, javaExecutableName(osName))
         return listOf(
             javaExecutable,
             "-cp",
@@ -41,10 +42,17 @@ internal object HeadlessModeSwitcher {
     }
 
     private fun String.isJavaExecutable(): Boolean {
-        val name = File(this).name.lowercase()
+        val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
         return name == "java" || name == "java.exe"
     }
 
-    private fun javaExecutableName(): String =
-        if (System.getProperty("os.name").lowercase().contains("windows")) "java.exe" else "java"
+    private fun javaExecutableName(osName: String): String =
+        if (osName.lowercase().contains("windows")) "java.exe" else "java"
+
+    private fun javaExecutablePath(javaHome: String, executableName: String): String =
+        if (javaHome.contains('\\')) {
+            "${javaHome.trimEnd('\\')}\\bin\\$executableName"
+        } else {
+            "${javaHome.trimEnd('/')}/bin/$executableName"
+        }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -58,12 +58,22 @@ private fun launchDesktop() = application {
         LaunchedEffect(Unit) {
             service = withContext(Dispatchers.IO) { WatcherService.create() }
         }
-        DaemonitorContent(service)
+        DaemonitorContent(
+            service = service,
+            onSwitchToHeadless = {
+                runCatching { HeadlessModeSwitcher.launch() }
+                    .onSuccess { exitApplication() }
+                    .onFailure { it.printStackTrace() }
+            },
+        )
     }
 }
 
 @Composable
-internal fun DaemonitorContent(service: WatcherService?) {
+internal fun DaemonitorContent(
+    service: WatcherService?,
+    onSwitchToHeadless: () -> Unit = {},
+) {
     if (service == null) {
         WatcherTheme {
             Surface(modifier = Modifier.fillMaxSize()) {
@@ -81,6 +91,7 @@ internal fun DaemonitorContent(service: WatcherService?) {
         Surface(modifier = Modifier.fillMaxSize()) {
             val liveState by service.liveViewModel.state.collectAsState()
             AppScaffold(
+                onSwitchToHeadless = onSwitchToHeadless,
                 liveContent = {
                     LiveMonitorScreen(
                         state = liveState,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
@@ -17,8 +17,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
+import androidx.compose.material.icons.filled.Terminal
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.SegmentedButton
@@ -44,11 +46,17 @@ fun AppScaffold(
     liveContent: @Composable () -> Unit,
     historyContent: @Composable () -> Unit,
     settingsContent: @Composable () -> Unit,
+    onSwitchToHeadless: () -> Unit = {},
     buildInfo: BuildInfo = BuildInfo.current,
 ) {
     var selectedTab by remember { mutableStateOf(0) }
     Column(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
-        AppHeader(buildInfo, selectedTab) { selectedTab = it }
+        AppHeader(
+            buildInfo = buildInfo,
+            selectedTab = selectedTab,
+            onSelectTab = { selectedTab = it },
+            onSwitchToHeadless = onSwitchToHeadless,
+        )
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         Column(modifier = Modifier.weight(1f)) {
             when (selectedTab) {
@@ -63,7 +71,12 @@ fun AppScaffold(
 /** A slim brand bar so the window reads as a product, not a bare tab strip. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun AppHeader(buildInfo: BuildInfo, selectedTab: Int, onSelectTab: (Int) -> Unit) {
+private fun AppHeader(
+    buildInfo: BuildInfo,
+    selectedTab: Int,
+    onSelectTab: (Int) -> Unit,
+    onSwitchToHeadless: () -> Unit,
+) {
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxWidth()
@@ -105,7 +118,19 @@ private fun AppHeader(buildInfo: BuildInfo, selectedTab: Int, onSelectTab: (Int)
                 }
             }
             Spacer(modifier = Modifier.weight(1f))
+            IconButton(
+                onClick = onSwitchToHeadless,
+                modifier = Modifier.size(40.dp),
+            ) {
+                Icon(
+                    Icons.Filled.Terminal,
+                    contentDescription = "Switch to headless mode",
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.size(20.dp),
+                )
+            }
             if (!compact) {
+                Spacer(modifier = Modifier.width(Space.xs))
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
                     androidx.compose.foundation.layout.Box(
                         modifier = Modifier.size(7.dp).background(LocalAccentColors.current.success, androidx.compose.foundation.shape.CircleShape),

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcherTest.kt
@@ -1,0 +1,40 @@
+package io.github.cdsap.daemonitor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HeadlessModeSwitcherTest {
+    @Test
+    fun `packaged application relaunches the current executable in headless mode`() {
+        val command = HeadlessModeSwitcher.commandForCurrentProcess(
+            executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
+            javaHome = "/unused/java",
+            classpath = "/unused/classpath",
+        )
+
+        assertEquals(
+            listOf("/Applications/Daemonitor.app/Contents/MacOS/Daemonitor", "--headless"),
+            command,
+        )
+    }
+
+    @Test
+    fun `source run relaunches the named desktop entry point with headless flag`() {
+        val command = HeadlessModeSwitcher.commandForCurrentProcess(
+            executable = "/opt/jdk/bin/java",
+            javaHome = "/opt/jdk",
+            classpath = "build/classes:kotlin-runtime.jar",
+        )
+
+        assertEquals(
+            listOf(
+                "/opt/jdk/bin/java",
+                "-cp",
+                "build/classes:kotlin-runtime.jar",
+                "io.github.cdsap.daemonitor.Daemonitor",
+                "--headless",
+            ),
+            command,
+        )
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcherTest.kt
@@ -10,6 +10,7 @@ class HeadlessModeSwitcherTest {
             executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
             javaHome = "/unused/java",
             classpath = "/unused/classpath",
+            osName = "Mac OS X",
         )
 
         assertEquals(
@@ -24,6 +25,7 @@ class HeadlessModeSwitcherTest {
             executable = "/opt/jdk/bin/java",
             javaHome = "/opt/jdk",
             classpath = "build/classes:kotlin-runtime.jar",
+            osName = "Linux",
         )
 
         assertEquals(
@@ -31,6 +33,27 @@ class HeadlessModeSwitcherTest {
                 "/opt/jdk/bin/java",
                 "-cp",
                 "build/classes:kotlin-runtime.jar",
+                "io.github.cdsap.daemonitor.Daemonitor",
+                "--headless",
+            ),
+            command,
+        )
+    }
+
+    @Test
+    fun `source run uses windows java executable name on windows`() {
+        val command = HeadlessModeSwitcher.commandForCurrentProcess(
+            executable = "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64\\bin\\java.exe",
+            javaHome = "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64",
+            classpath = "build/classes;kotlin-runtime.jar",
+            osName = "Windows Server 2025",
+        )
+
+        assertEquals(
+            listOf(
+                "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64\\bin\\java.exe",
+                "-cp",
+                "build/classes;kotlin-runtime.jar",
                 "io.github.cdsap.daemonitor.Daemonitor",
                 "--headless",
             ),

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.BuildInfo
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 @OptIn(ExperimentalTestApi::class)
 class AppScaffoldUiTest {
@@ -59,5 +60,25 @@ class AppScaffoldUiTest {
         onNodeWithText("History content").assertExists()
         onNodeWithText("Settings").performClick()
         onNodeWithText("Settings content").assertExists()
+    }
+
+    @Test
+    fun `header exposes switch to headless action`() = runComposeUiTest {
+        var switchedToHeadless = false
+
+        setContent {
+            WatcherTheme {
+                AppScaffold(
+                    liveContent = { Text("Live") },
+                    historyContent = { Text("History") },
+                    settingsContent = { Text("Settings") },
+                    onSwitchToHeadless = { switchedToHeadless = true },
+                )
+            }
+        }
+
+        onNodeWithContentDescription("Switch to headless mode").performClick()
+
+        assertTrue(switchedToHeadless)
     }
 }


### PR DESCRIPTION
## Summary

Daemonitor can now move from the desktop UI into headless collection from the top bar. The toolbar action relaunches the current packaged app with `--headless`, or uses the Java classpath entry point when running from source, then closes the desktop window after the headless process starts.

## Validation

- `./gradlew test --tests io.github.cdsap.daemonitor.HeadlessModeSwitcherTest --tests io.github.cdsap.daemonitor.ui.common.AppScaffoldUiTest --no-daemon --stacktrace`
- `./gradlew test --no-daemon --stacktrace`
