### PR TITLE
fix: include java sql in native runtime

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,6 +122,7 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Daemonitor"
             packageVersion = nativePackageVersion
+            modules("java.sql")
 
             // Per-platform installer/app icons (jpackage requires the native format per OS).
             macOS { iconFile.set(project.file("icons/daemonitor.icns")) }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DesktopDockIcon.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DesktopDockIcon.kt
@@ -1,0 +1,17 @@
+package io.github.cdsap.daemonitor
+
+import java.awt.Taskbar
+import javax.imageio.ImageIO
+
+internal object DesktopDockIcon {
+    fun configure(osName: String = System.getProperty("os.name")) {
+        if (!osName.lowercase().contains("mac")) return
+        runCatching {
+            if (!Taskbar.isTaskbarSupported()) return
+            val taskbar = Taskbar.getTaskbar()
+            if (!taskbar.isSupported(Taskbar.Feature.ICON_IMAGE)) return
+            val iconUrl = checkNotNull(javaClass.classLoader.getResource("icon/daemonitor.png"))
+            taskbar.iconImage = ImageIO.read(iconUrl)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
@@ -19,6 +19,9 @@ internal object DesktopModeSwitcher {
         osName: String = System.getProperty("os.name"),
     ): List<String> {
         if (executable != null && !executable.isJavaExecutable()) {
+            if (osName.isMacOs()) {
+                executable.macAppBundlePath()?.let { return listOf("/usr/bin/open", "-n", it) }
+            }
             return listOf(executable)
         }
 
@@ -43,6 +46,15 @@ internal object DesktopModeSwitcher {
         val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
         return name == "java" || name == "java.exe"
     }
+
+    private fun String.macAppBundlePath(): String? {
+        val marker = ".app/Contents/MacOS/"
+        val index = indexOf(marker)
+        if (index < 0) return null
+        return substring(0, index + ".app".length)
+    }
+
+    private fun String.isMacOs(): Boolean = lowercase().contains("mac")
 
     private fun javaExecutableName(osName: String): String =
         if (osName.lowercase().contains("windows")) "java.exe" else "java"

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
@@ -1,0 +1,56 @@
+package io.github.cdsap.daemonitor
+
+import java.io.File
+
+internal object DesktopModeSwitcher {
+    fun launch(): Process {
+        val command = currentProcessCommand()
+        val builder = ProcessBuilder(command)
+            .directory(File(System.getProperty("user.dir")))
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+        return builder.start()
+    }
+
+    internal fun commandForCurrentProcess(
+        executable: String?,
+        javaHome: String,
+        classpath: String,
+        osName: String = System.getProperty("os.name"),
+    ): List<String> {
+        if (executable != null && !executable.isJavaExecutable()) {
+            return listOf(executable)
+        }
+
+        return listOf(
+            javaExecutablePath(javaHome, javaExecutableName(osName)),
+            "-cp",
+            classpath,
+            "io.github.cdsap.daemonitor.Daemonitor",
+        )
+    }
+
+    private fun currentProcessCommand(): List<String> {
+        val info = ProcessHandle.current().info()
+        return commandForCurrentProcess(
+            executable = info.command().orElse(null),
+            javaHome = System.getProperty("java.home"),
+            classpath = System.getProperty("java.class.path"),
+        )
+    }
+
+    private fun String.isJavaExecutable(): Boolean {
+        val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
+        return name == "java" || name == "java.exe"
+    }
+
+    private fun javaExecutableName(osName: String): String =
+        if (osName.lowercase().contains("windows")) "java.exe" else "java"
+
+    private fun javaExecutablePath(javaHome: String, executableName: String): String =
+        if (javaHome.contains('\\')) {
+            "${javaHome.trimEnd('\\')}\\bin\\$executableName"
+        } else {
+            "${javaHome.trimEnd('/')}/bin/$executableName"
+        }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMacMode.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMacMode.kt
@@ -1,0 +1,11 @@
+package io.github.cdsap.daemonitor
+
+internal object HeadlessMacMode {
+    fun configure(osName: String = System.getProperty("os.name")) {
+        val normalized = osName.lowercase()
+        if (normalized.contains("mac") || normalized.contains("darwin")) {
+            System.setProperty("apple.awt.UIElement", "true")
+            System.setProperty("apple.awt.application.name", "Daemonitor")
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import java.io.PrintStream
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -32,18 +33,27 @@ internal object HeadlessLauncher {
         val runtime = WatcherRuntime.create(database)
         val retentionDays = SettingsStore().load().retentionDays
         val pollingThread = Thread.currentThread()
+        val running = AtomicBoolean(true)
         val cleanupFinished = CountDownLatch(1)
         val shutdownHook = Thread({
+            running.set(false)
             pollingThread.interrupt()
             cleanupFinished.await(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         }, "daemonitor-headless-shutdown")
+        val tray = HeadlessTray.install(
+            onQuit = {
+                running.set(false)
+                pollingThread.interrupt()
+            },
+            error = error,
+        )
 
         return try {
             database.purgeOlderThan(System.currentTimeMillis(), retentionDays)
             Runtime.getRuntime().addShutdownHook(shutdownHook)
             output.println("Daemonitor headless collector started")
             runBlocking {
-                while (currentCoroutineContext().isActive) {
+                while (currentCoroutineContext().isActive && running.get()) {
                     runCatching { runtime.pollOnce() }
                         .onFailure { error.println("Daemonitor poll failed: ${it.message}") }
                     delay(Defaults.POLL_INTERVAL)
@@ -58,6 +68,7 @@ internal object HeadlessLauncher {
             try {
                 database.close()
             } finally {
+                tray.close()
                 cleanupFinished.countDown()
                 runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
             }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -29,6 +29,7 @@ internal object HeadlessLauncher {
             return 2
         }
 
+        HeadlessMacMode.configure()
         val database = WatcherDatabase.open()
         val runtime = WatcherRuntime.create(database)
         val retentionDays = SettingsStore().load().retentionDays
@@ -41,6 +42,14 @@ internal object HeadlessLauncher {
             cleanupFinished.await(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         }, "daemonitor-headless-shutdown")
         val tray = HeadlessTray.install(
+            onOpen = {
+                runCatching { DesktopModeSwitcher.launch() }
+                    .onSuccess {
+                        running.set(false)
+                        pollingThread.interrupt()
+                    }
+                    .onFailure { error.println("Daemonitor desktop launch failed: ${it.message}") }
+            },
             onQuit = {
                 running.set(false)
                 pollingThread.interrupt()

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessTray.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessTray.kt
@@ -1,0 +1,73 @@
+package io.github.cdsap.daemonitor
+
+import java.awt.Image
+import java.awt.MenuItem
+import java.awt.PopupMenu
+import java.awt.SystemTray
+import java.awt.Toolkit
+import java.awt.TrayIcon
+import java.io.PrintStream
+
+internal interface HeadlessTrayHandle : AutoCloseable
+
+internal object NoHeadlessTrayHandle : HeadlessTrayHandle {
+    override fun close() = Unit
+}
+
+internal object HeadlessTray {
+    fun install(
+        onQuit: () -> Unit,
+        error: PrintStream = System.err,
+        environment: TrayEnvironment = AwtTrayEnvironment,
+    ): HeadlessTrayHandle {
+        if (!environment.isSupported()) return NoHeadlessTrayHandle
+
+        return runCatching {
+            val image = environment.loadImage("icon/daemonitor.png")
+            val popup = PopupMenu().apply {
+                add(MenuItem("Quit Daemonitor").apply {
+                    addActionListener { onQuit() }
+                })
+            }
+            val icon = TrayIcon(image, "Daemonitor is collecting Gradle activity", popup).apply {
+                isImageAutoSize = true
+            }
+            environment.add(icon)
+            object : HeadlessTrayHandle {
+                override fun close() {
+                    environment.remove(icon)
+                }
+            }
+        }.getOrElse {
+            error.println("Daemonitor tray icon unavailable: ${it.message}")
+            NoHeadlessTrayHandle
+        }
+    }
+}
+
+internal interface TrayEnvironment {
+    fun isSupported(): Boolean
+    fun loadImage(resourcePath: String): Image
+    fun add(icon: TrayIcon)
+    fun remove(icon: TrayIcon)
+}
+
+internal object AwtTrayEnvironment : TrayEnvironment {
+    override fun isSupported(): Boolean =
+        runCatching { SystemTray.isSupported() }.getOrDefault(false)
+
+    override fun loadImage(resourcePath: String): Image {
+        val resource = requireNotNull(Thread.currentThread().contextClassLoader.getResource(resourcePath)) {
+            "Missing tray icon resource: $resourcePath"
+        }
+        return Toolkit.getDefaultToolkit().getImage(resource)
+    }
+
+    override fun add(icon: TrayIcon) {
+        SystemTray.getSystemTray().add(icon)
+    }
+
+    override fun remove(icon: TrayIcon) {
+        SystemTray.getSystemTray().remove(icon)
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessTray.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessTray.kt
@@ -16,6 +16,7 @@ internal object NoHeadlessTrayHandle : HeadlessTrayHandle {
 
 internal object HeadlessTray {
     fun install(
+        onOpen: () -> Unit,
         onQuit: () -> Unit,
         error: PrintStream = System.err,
         environment: TrayEnvironment = AwtTrayEnvironment,
@@ -25,6 +26,9 @@ internal object HeadlessTray {
         return runCatching {
             val image = environment.loadImage("icon/daemonitor.png")
             val popup = PopupMenu().apply {
+                add(MenuItem("Open Daemonitor").apply {
+                    addActionListener { onOpen() }
+                })
                 add(MenuItem("Quit Daemonitor").apply {
                     addActionListener { onQuit() }
                 })

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -39,6 +39,7 @@ fun main(args: Array<String>) {
         if (exitCode != 0) kotlin.system.exitProcess(exitCode)
         return
     }
+    DesktopDockIcon.configure()
     launchDesktop()
 }
 

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -5,6 +5,7 @@ import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
 import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.domain.BuildAggregator
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.domain.model.ProcessType
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 
 /** UI-independent collection and persistence runtime shared by desktop and headless launchers. */
@@ -32,15 +33,14 @@ class WatcherRuntime(
         return PollResult(
             processes = processes,
             daemonLogs = logs,
-            buildsChanged = processForBuilds(logs),
+            buildsChanged = processForBuilds(logs, activeDaemonPids = processes.activeDaemonPids()),
         )
     }
 
     fun tailFor(logs: List<DaemonLog>, pid: Long): List<String> =
         logs.firstOrNull { it.pid == pid }?.let { logWatcher.tailFor(it.path) }.orEmpty()
 
-    private fun processForBuilds(logs: List<DaemonLog>): Boolean {
-        val currentPids = logs.map { it.pid }.toSet()
+    internal fun processForBuilds(logs: List<DaemonLog>, activeDaemonPids: Set<Long>): Boolean {
         var inserted = false
 
         for (log in logs) {
@@ -51,17 +51,26 @@ class WatcherRuntime(
                     inserted = true
                 }
             }
+            if (log.pid !in activeDaemonPids) {
+                aggregator.onDaemonGone(log.pid)?.let {
+                    database.insertBuild(it)
+                    inserted = true
+                }
+            }
         }
 
-        (knownDaemonPids - currentPids).forEach { gonePid ->
+        (knownDaemonPids - activeDaemonPids).forEach { gonePid ->
             aggregator.onDaemonGone(gonePid)?.let {
                 database.insertBuild(it)
                 inserted = true
             }
         }
-        knownDaemonPids = currentPids
+        knownDaemonPids = activeDaemonPids
         return inserted
     }
+
+    private fun List<GradleProcess>.activeDaemonPids(): Set<Long> =
+        filter { it.type == ProcessType.GRADLE_DAEMON }.map { it.pid }.toSet()
 
     companion object {
         fun create(database: WatcherDatabase): WatcherRuntime = WatcherRuntime(

--- a/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
@@ -87,12 +87,20 @@ class BuildAggregator(
         return emitted
     }
 
-    /** Daemon PID disappeared: emit an interrupted build if one was in flight. */
+    /** Daemon PID disappeared: emit a qualified open build instead of leaving it stuck forever. */
     fun onDaemonGone(daemonPid: Long): Build? {
         val state = daemons.remove(daemonPid) ?: return null
         val w = state.window ?: return null
         if (!w.qualified) return null
-        return w.toBuild(daemonPid, state.uid, endMs = null, sampleProvider, ambientEnvNames, interrupted = true)
+        val inferredEndMs = w.outcomeDurationSeconds?.let { w.busyTimeMs + (it * 1000).toLong() }
+        return w.toBuild(
+            daemonPid,
+            state.uid,
+            endMs = inferredEndMs,
+            sampleProvider,
+            ambientEnvNames,
+            interrupted = w.outcomeSuccess == null,
+        )
     }
 
     private class DaemonState(

--- a/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertEquals
 
 class DesktopModeSwitcherTest {
     @Test
-    fun `packaged application relaunches the current executable without headless mode`() {
+    fun `packaged mac application relaunches the bundle without headless mode`() {
         val command = DesktopModeSwitcher.commandForCurrentProcess(
             executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
             javaHome = "/unused/java",
@@ -13,7 +13,19 @@ class DesktopModeSwitcherTest {
             osName = "Mac OS X",
         )
 
-        assertEquals(listOf("/Applications/Daemonitor.app/Contents/MacOS/Daemonitor"), command)
+        assertEquals(listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"), command)
+    }
+
+    @Test
+    fun `packaged non-mac application relaunches the current executable without headless mode`() {
+        val command = DesktopModeSwitcher.commandForCurrentProcess(
+            executable = "/opt/Daemonitor/bin/Daemonitor",
+            javaHome = "/unused/java",
+            classpath = "/unused/classpath",
+            osName = "Linux",
+        )
+
+        assertEquals(listOf("/opt/Daemonitor/bin/Daemonitor"), command)
     }
 
     @Test

--- a/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
@@ -1,0 +1,38 @@
+package io.github.cdsap.daemonitor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopModeSwitcherTest {
+    @Test
+    fun `packaged application relaunches the current executable without headless mode`() {
+        val command = DesktopModeSwitcher.commandForCurrentProcess(
+            executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
+            javaHome = "/unused/java",
+            classpath = "/unused/classpath",
+            osName = "Mac OS X",
+        )
+
+        assertEquals(listOf("/Applications/Daemonitor.app/Contents/MacOS/Daemonitor"), command)
+    }
+
+    @Test
+    fun `source run relaunches the named desktop entry point`() {
+        val command = DesktopModeSwitcher.commandForCurrentProcess(
+            executable = "/opt/jdk/bin/java",
+            javaHome = "/opt/jdk",
+            classpath = "build/classes:kotlin-runtime.jar",
+            osName = "Linux",
+        )
+
+        assertEquals(
+            listOf(
+                "/opt/jdk/bin/java",
+                "-cp",
+                "build/classes:kotlin-runtime.jar",
+                "io.github.cdsap.daemonitor.Daemonitor",
+            ),
+            command,
+        )
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessMacModeTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessMacModeTest.kt
@@ -1,0 +1,46 @@
+package io.github.cdsap.daemonitor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HeadlessMacModeTest {
+    @Test
+    fun `mac headless mode hides awt from the dock`() {
+        val previousUiElement = System.getProperty("apple.awt.UIElement")
+        val previousName = System.getProperty("apple.awt.application.name")
+        try {
+            System.clearProperty("apple.awt.UIElement")
+            System.clearProperty("apple.awt.application.name")
+
+            HeadlessMacMode.configure(osName = "Mac OS X")
+
+            assertEquals("true", System.getProperty("apple.awt.UIElement"))
+            assertEquals("Daemonitor", System.getProperty("apple.awt.application.name"))
+        } finally {
+            restoreProperty("apple.awt.UIElement", previousUiElement)
+            restoreProperty("apple.awt.application.name", previousName)
+        }
+    }
+
+    @Test
+    fun `non mac headless mode leaves awt properties alone`() {
+        val previousUiElement = System.getProperty("apple.awt.UIElement")
+        val previousName = System.getProperty("apple.awt.application.name")
+        try {
+            System.clearProperty("apple.awt.UIElement")
+            System.clearProperty("apple.awt.application.name")
+
+            HeadlessMacMode.configure(osName = "Linux")
+
+            assertEquals(null, System.getProperty("apple.awt.UIElement"))
+            assertEquals(null, System.getProperty("apple.awt.application.name"))
+        } finally {
+            restoreProperty("apple.awt.UIElement", previousUiElement)
+            restoreProperty("apple.awt.application.name", previousName)
+        }
+    }
+
+    private fun restoreProperty(name: String, value: String?) {
+        if (value == null) System.clearProperty(name) else System.setProperty(name, value)
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessTrayTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessTrayTest.kt
@@ -14,6 +14,7 @@ class HeadlessTrayTest {
         val error = ByteArrayOutputStream()
 
         val handle = HeadlessTray.install(
+            onOpen = {},
             onQuit = {},
             error = PrintStream(error),
             environment = UnsupportedTrayEnvironment,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessTrayTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/HeadlessTrayTest.kt
@@ -1,0 +1,32 @@
+package io.github.cdsap.daemonitor
+
+import java.awt.Image
+import java.awt.TrayIcon
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class HeadlessTrayTest {
+    @Test
+    fun `unsupported tray environment does not fail headless startup`() {
+        val error = ByteArrayOutputStream()
+
+        val handle = HeadlessTray.install(
+            onQuit = {},
+            error = PrintStream(error),
+            environment = UnsupportedTrayEnvironment,
+        )
+
+        assertSame(NoHeadlessTrayHandle, handle)
+        assertEquals("", error.toString())
+    }
+
+    private object UnsupportedTrayEnvironment : TrayEnvironment {
+        override fun isSupported(): Boolean = false
+        override fun loadImage(resourcePath: String): Image = error("should not load image")
+        override fun add(icon: TrayIcon) = error("should not add icon")
+        override fun remove(icon: TrayIcon) = error("should not remove icon")
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
 import io.github.cdsap.daemonitor.domain.BuildAggregator
+import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import java.nio.file.Files
 import java.nio.file.Path
@@ -54,6 +55,37 @@ class WatcherRuntimeTest {
             assertFalse(snippet.contains("outside before window"))
             assertFalse(snippet.contains("outside after window"))
             assertEquals(5, snippet.lines().size)
+        }
+    }
+
+    @Test
+    fun `inactive daemon log with outcome but no idle is persisted`(
+        @org.junit.jupiter.api.io.TempDir tmp: Path,
+    ) {
+        val versionDir = tmp.resolve("gradle/daemon/9.6.1").also { it.createDirectories() }
+        val log = versionDir.resolve("daemon-75597.out.log")
+        log.writeText(
+            buildString {
+                appendLine("2026-07-28T10:20:45.687-0700 [INFO] [org.gradle.launcher.daemon.server.DaemonRegistryUpdater] Marking the daemon as busy, address: []")
+                appendLine("2026-07-28T10:20:45.689-0700 [INFO] [org.gradle.launcher.daemon.server.exec.StartBuildOrRespondWithBusy] Daemon is about to start building Build{id=build-96, currentDir=/project}")
+                appendLine("BUILD SUCCESSFUL in 2s")
+            },
+        )
+
+        WatcherDatabase.open(tmp.resolve("watcher.db")).use { database ->
+            val logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle"))
+            val runtime = WatcherRuntime(
+                logWatcher = logWatcher,
+                aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
+                database = database,
+            )
+
+            val changed = runtime.processForBuilds(logWatcher.discover(), activeDaemonPids = emptySet())
+
+            assertTrue(changed)
+            val build = database.recentBuilds().single()
+            assertEquals("build-96", build.buildId)
+            assertEquals(FinalStatus.SUCCESS, build.finalStatus)
         }
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
@@ -84,6 +84,21 @@ class BuildAggregatorTest {
     }
 
     @Test
+    fun `daemon disappearing after outcome emits completed build`() {
+        val samples = listOf(100L to 20.0, 140L to 50.0)
+        val agg = BuildAggregator(sampleProvider = { _, _, _ -> samples })
+        agg.onEvents(pid, listOf(context(0), BusyMark(1_000), start(1_010), Outcome(true, 2.0)))
+
+        val b = agg.onDaemonGone(pid)!!
+
+        assertEquals(FinalStatus.SUCCESS, b.finalStatus)
+        assertEquals(3_000, b.endTimeMs)
+        assertEquals(2.0, b.durationSeconds)
+        assertEquals(140L, b.peakMemoryMb)
+        assertEquals(50.0, b.peakCpuPercent)
+    }
+
+    @Test
     fun `interrupted build retains its bounded in-window log excerpt`() {
         val agg = BuildAggregator()
         agg.onLogLine(pid, "busy", BusyMark(1_000))


### PR DESCRIPTION
## Summary

The installed native app can now run headless collection cleanly and return to desktop mode with the expected macOS app identity. The packaged runtime image carries the JDK `java.sql` module required by SQLDelight's SQLite JDBC driver, headless mode installs a system tray/menu-bar icon with Open and Quit actions, and the Open action relaunches the `.app` bundle through LaunchServices so the foreground Dock icon uses the app icon instead of the executable icon.

Historical builds now populate from existing Gradle daemon logs even when a one-shot daemon exits after writing `BUILD SUCCESSFUL`/`BUILD FAILED` without a final idle marker. Completed windows are flushed when the daemon PID is inactive, while genuinely missing outcomes still remain interrupted.

## Validation

- `./gradlew test --no-daemon --stacktrace`
- `./gradlew test --tests io.github.cdsap.daemonitor.DesktopModeSwitcherTest --tests io.github.cdsap.daemonitor.HeadlessMacModeTest --tests io.github.cdsap.daemonitor.HeadlessTrayTest --tests io.github.cdsap.daemonitor.HeadlessLauncherTest --no-daemon --stacktrace`
- `./gradlew test --tests io.github.cdsap.daemonitor.domain.BuildAggregatorTest --tests io.github.cdsap.daemonitor.WatcherRuntimeTest --tests io.github.cdsap.daemonitor.DesktopModeSwitcherTest --no-daemon --stacktrace`
- `./gradlew createDistributable packageDmg --no-daemon --stacktrace`
- Verified the rebuilt app runtime manifest includes `java.sql`.
- Reinstalled `/Applications/Daemonitor.app` and confirmed `/Applications/Daemonitor.app/Contents/MacOS/Daemonitor --headless` starts with `Daemonitor headless collector started`.
- Verified the installed app processed existing local daemon logs: `builds` increased from `0` to `21`, with recent history rows for `/Users/factory/projects/daemonitor`.
