### PR TITLE
ci: publish native packages on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            exit 0
+          fi
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "Daemonitor ${TAG_NAME}"
+
+  build-assets:
+    name: Build release asset (${{ matrix.os }})
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            platform: linux
+            package_task: packageDeb
+            package_glob: build/compose/binaries/main/deb/*.deb
+            launcher: build/compose/binaries/main/app/Daemonitor/bin/Daemonitor
+          - os: windows-latest
+            platform: windows
+            package_task: packageMsi
+            package_glob: build/compose/binaries/main/msi/*.msi
+            launcher: build/compose/binaries/main/app/Daemonitor/Daemonitor.exe
+          - os: macos-latest
+            platform: macos
+            package_task: packageDmg
+            package_glob: build/compose/binaries/main/dmg/*.dmg
+            launcher: build/compose/binaries/main/app/Daemonitor.app/Contents/MacOS/Daemonitor
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run tests (Linux, virtual display)
+        if: runner.os == 'Linux'
+        run: xvfb-run -a ./gradlew test --no-daemon --stacktrace
+
+      - name: Run tests (macOS / Windows)
+        if: runner.os != 'Linux'
+        run: ./gradlew test --no-daemon --stacktrace
+
+      - name: Build native application and installer
+        run: ./gradlew createDistributable ${{ matrix.package_task }} --no-daemon --stacktrace
+
+      - name: Smoke test packaged launcher
+        run: |
+          output=$("${{ matrix.launcher }}" --headless --help)
+          printf '%s\n' "$output"
+          [[ "$output" == *"Usage: daemonitor --headless"* ]]
+
+      - name: Read package version
+        id: package-version
+        run: echo "value=$(./gradlew -q printNativePackageVersion --no-daemon)" >> "$GITHUB_OUTPUT"
+
+      - name: Stage release asset
+        id: asset
+        run: |
+          shopt -s nullglob
+          packages=(${{ matrix.package_glob }})
+          if (( ${#packages[@]} != 1 )); then
+            echo "Expected one native installer, found ${#packages[@]}" >&2
+            exit 1
+          fi
+          test -s "${packages[0]}"
+          extension="${packages[0]##*.}"
+          asset="Daemonitor-${{ steps.package-version.outputs.value }}-${{ matrix.platform }}.${extension}"
+          mkdir -p release-assets
+          cp "${packages[0]}" "release-assets/${asset}"
+          echo "path=release-assets/${asset}" >> "$GITHUB_OUTPUT"
+          echo "name=${asset}" >> "$GITHUB_OUTPUT"
+          echo "### Release asset" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Platform: ${{ matrix.platform }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Asset: ${asset}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload asset to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+          ASSET_PATH: ${{ steps.asset.outputs.path }}
+        run: |
+          gh release upload "$TAG_NAME" "$ASSET_PATH" --clobber


### PR DESCRIPTION
## Summary

Add a tag-triggered release workflow for Daemonitor.

When a `v*` tag is pushed, the workflow:

- creates a GitHub release for the tag
- builds and tests the app on Linux, Windows, and macOS
- packages the native installer for each OS
- smoke-tests the packaged launcher with `--headless --help`
- uploads release assets named from the native package version:
  - `Daemonitor-<version>-linux.deb`
  - `Daemonitor-<version>-windows.msi`
  - `Daemonitor-<version>-macos.dmg`

## Validation

- Parsed `.github/workflows/release.yml` with Ruby YAML loader
- `git diff --check`
- Reused the same package tasks, launcher paths, and native package version task that CI already validates
