### PR TITLE
ci: set repository for release commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Create or update release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
@@ -111,6 +112,7 @@ jobs:
       - name: Upload asset to GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
           TAG_NAME: ${{ github.ref_name }}
           ASSET_PATH: ${{ steps.asset.outputs.path }}
         run: |


### PR DESCRIPTION
## Summary

Fix the tag-triggered release workflow so `gh release` commands know which repository to use.

The first `v1.0.1` tag run failed in `Create GitHub release` because that job does not check out the repository, and `gh release create` tried to infer the repo from `.git`:

```text
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

This sets `GH_REPO: ${{ github.repository }}` for both release creation and asset upload.

## Validation

- Parsed `.github/workflows/release.yml` with Ruby YAML loader
- `git diff --check`
