### PR TITLE
fix: verify why history shows builds with ide and claude

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
@@ -150,7 +150,12 @@ class BuildAggregator(
             }
             val duration = outcomeDurationSeconds
                 ?: endMs?.let { (it - busyTimeMs) / 1000.0 }
-            val agentAttr = AgentDetector.detect(envNames, ambientEnvNames)
+            val source = SourceDetector.detect(envNames)
+            val agentAttr = if (source == Source.IDE) {
+                null
+            } else {
+                AgentDetector.detect(envNames, ambientEnvNames)
+            }
 
             return Build(
                 buildId = buildId ?: "$daemonPid-$busyTimeMs",
@@ -165,7 +170,7 @@ class BuildAggregator(
                 peakMemoryMb = rss.maxOrNull(),
                 avgMemoryMb = if (rss.isEmpty()) null else rss.average().toLong(),
                 peakCpuPercent = cpu.maxOrNull(),
-                inferredSource = SourceDetector.detect(envNames),
+                inferredSource = source,
                 finalStatus = status,
                 logSnippet = logLines.takeIf { it.isNotEmpty() }?.joinToString("\n"),
                 agent = agentAttr?.agent,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.domain.model.Source
 import io.github.cdsap.daemonitor.ui.common.Cell
 import io.github.cdsap.daemonitor.ui.common.CellSlot
 import io.github.cdsap.daemonitor.ui.common.Col
@@ -151,6 +152,7 @@ private fun ProjectDropdown(projects: List<String>, selected: String?, onProject
 @Composable
 private fun BuildRow(b: Build, selected: Boolean, onSelect: () -> Unit) {
     val bg = if (selected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.65f) else MaterialTheme.colorScheme.surface
+    val agent = b.displayAgent()
     Row(
         modifier = Modifier
             .fillMaxWidth()
@@ -171,7 +173,7 @@ private fun BuildRow(b: Build, selected: Boolean, onSelect: () -> Unit) {
         Cell(b.peakMemoryMb?.let { "$it MB" } ?: "not sampled", COLS[3], muted = b.peakMemoryMb == null)
         CellSlot(COLS[4]) { StatusPill(b.finalStatus) }
         CellSlot(COLS[5]) { SourcePill(b.inferredSource) }
-        CellSlot(COLS[6]) { AgentLabel(b.agent) }
+        CellSlot(COLS[6]) { AgentLabel(agent) }
     }
 }
 
@@ -199,6 +201,7 @@ private fun HistoryDetail(build: Build?) {
         Text("Select a build to see details.", color = MaterialTheme.colorScheme.onSurfaceVariant, style = MaterialTheme.typography.bodyMedium)
         return
     }
+    val agent = build.displayAgent()
     Column(modifier = Modifier.fillMaxSize()) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.sm)) {
             ProcessTypeIcon(ProcessType.GRADLE_DAEMON, size = 18.dp)
@@ -212,8 +215,8 @@ private fun HistoryDetail(build: Build?) {
         DetailRow("Avg memory", build.avgMemoryMb?.let { "$it MB" } ?: "not sampled (<2s)")
         DetailRow("Peak CPU", build.peakCpuPercent?.let { "%.0f%%".format(it) } ?: "not sampled (<2s)")
         DetailRow("Source", build.inferredSource.name.lowercase())
-        DetailRow("Agent", build.agent ?: "not detected")
-        DetailRow("LLM provider", build.agent?.let { build.agentProvider ?: "unknown" } ?: "—")
+        DetailRow("Agent", agent ?: "not detected")
+        DetailRow("LLM provider", agent?.let { build.agentProvider ?: "unknown" } ?: "—")
         Spacer(Modifier.padding(Space.xs))
         Text(
             "Build log excerpt — captured during the build window",
@@ -239,6 +242,7 @@ private fun DetailRow(label: String, value: String) {
 }
 
 private val TIME_FMT = DateTimeFormatter.ofPattern("MMM d, HH:mm:ss").withZone(ZoneId.systemDefault())
+private fun Build.displayAgent(): String? = agent.takeUnless { inferredSource == Source.IDE }
 private fun formatTime(ms: Long): String = TIME_FMT.format(Instant.ofEpochMilli(ms))
 private fun formatDuration(seconds: Double?): String =
     seconds?.let { if (it < 1) "%.0f ms".format(it * 1000) else "%.1f s".format(it) } ?: "—"

--- a/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
@@ -147,6 +147,26 @@ class BuildAggregatorTest {
     }
 
     @Test
+    fun `ide builds do not get attributed to inherited Claude agent env names`() {
+        val agg = BuildAggregator()
+        val b = agg.onEvents(
+            pid,
+            listOf(
+                context(0), BusyMark(1_000), start(1_010),
+                BuildEnvNames(
+                    1_020,
+                    listOf("PATH", "VSCODE_GIT_IPC_HANDLE", "CLAUDECODE", "CLAUDE_CODE_SESSION_ID", "AI_AGENT"),
+                ),
+                Outcome(true, 1.0), IdleMark(2_000),
+            ),
+        ).single()
+
+        assertEquals(Source.IDE, b.inferredSource)
+        assertNull(b.agent)
+        assertNull(b.agentProvider)
+    }
+
+    @Test
     fun `a second busy mark with no intervening idle flushes the first build`() {
         val agg = BuildAggregator()
         // First build qualifies but its IdleMark is missing; a new BusyMark arrives.

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
@@ -48,6 +48,22 @@ class HistoryScreenUiTest {
     }
 
     @Test
+    fun `ide build rows suppress stale stored agent labels`() = runComposeUiTest {
+        val state = HistoryUiState(
+            builds = listOf(sampleBuild().copy(inferredSource = Source.IDE)),
+            isEmptyResult = false,
+        )
+        setContent {
+            WatcherTheme(appearance = AppearancePreference.DARK) {
+                HistoryScreen(state, onProject = {}, onTimeRange = {})
+            }
+        }
+
+        onNodeWithText("IDE").assertExists()
+        onNodeWithText("Claude Code").assertDoesNotExist()
+    }
+
+    @Test
     fun `empty result shows the empty state`() = runComposeUiTest {
         val state = HistoryUiState(builds = emptyList(), isEmptyResult = true)
         setContent { WatcherTheme { HistoryScreen(state, onProject = {}, onTimeRange = {}) } }


### PR DESCRIPTION
## Summary

Automated Codex implementation for cdsap/daemonitor#46: Verify why history shows builds with IDE and Claude

Fixes #46

## Verification

- `./gradlew test`