### PR TITLE
feat: add manual update checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ Daemonitor is distributed as a native desktop app per operating system:
 The installed app does not require a project-local Gradle setup. It only reads local process
 metadata and Gradle daemon logs for the current user.
 
+## Updates
+
+The Settings tab can check GitHub Releases for a newer Daemonitor version. When a newer release is
+available, Daemonitor shows the matching installer for the current operating system and opens the
+download only after you approve it. The app does not silently install updates.
+
 ## Run from source
 
 Source builds require **JDK 17+** to launch Gradle; the pinned Java 21 toolchain is provisioned

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,7 +122,7 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Daemonitor"
             packageVersion = nativePackageVersion
-            modules("java.sql")
+            modules("java.sql", "java.net.http")
 
             // Per-platform installer/app icons (jpackage requires the native format per OS).
             macOS { iconFile.set(project.file("icons/daemonitor.icns")) }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -113,6 +113,8 @@ internal fun DaemonitorContent(
                         state = settingsState,
                         onRetentionDays = service.settingsViewModel::setRetentionDays,
                         onAppearance = service.settingsViewModel::setAppearance,
+                        onCheckForUpdates = service.settingsViewModel::checkForUpdates,
+                        onOpenUpdate = service.settingsViewModel::openUpdate,
                     )
                 },
             )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -9,12 +9,18 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SystemUpdate
+import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,6 +41,8 @@ fun SettingsScreen(
     state: SettingsUiState,
     onRetentionDays: (Long) -> Unit,
     onAppearance: (AppearancePreference) -> Unit = {},
+    onCheckForUpdates: () -> Unit = {},
+    onOpenUpdate: (io.github.cdsap.daemonitor.update.UpdateCandidate) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -70,6 +78,47 @@ fun SettingsScreen(
                                 selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer,
                             ),
                         )
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(Space.md))
+        SectionCard(
+            "Updates",
+            modifier = Modifier.fillMaxWidth().height(180.dp).padding(horizontal = Space.lg),
+        ) {
+            Column {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
+                    Icon(Icons.Filled.SystemUpdate, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                    Text("Application updates", style = MaterialTheme.typography.bodyMedium)
+                }
+                Spacer(Modifier.height(Space.sm))
+                Text(
+                    state.updateState.message,
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(Space.md))
+                Row(horizontalArrangement = Arrangement.spacedBy(Space.sm), verticalAlignment = Alignment.CenterVertically) {
+                    OutlinedButton(
+                        onClick = onCheckForUpdates,
+                        enabled = state.updateState != UpdateUiState.Checking,
+                        shape = RoundedCornerShape(Radius.sm),
+                    ) {
+                        Icon(Icons.Filled.Refresh, contentDescription = null)
+                        Spacer(Modifier.width(Space.xs))
+                        Text(if (state.updateState == UpdateUiState.Checking) "Checking" else "Check for updates")
+                    }
+                    val available = state.updateState as? UpdateUiState.Available
+                    if (available != null) {
+                        Button(
+                            onClick = { onOpenUpdate(available.candidate) },
+                            shape = RoundedCornerShape(Radius.sm),
+                        ) {
+                            Icon(Icons.Filled.Download, contentDescription = null)
+                            Spacer(Modifier.width(Space.xs))
+                            Text("Open installer")
+                        }
                     }
                 }
             }
@@ -119,3 +168,12 @@ fun SettingsScreen(
 
 private val AppearancePreference.displayName: String
     get() = name.lowercase().replaceFirstChar(Char::uppercase)
+
+private val UpdateUiState.message: String
+    get() = when (this) {
+        UpdateUiState.NotChecked -> "Check GitHub Releases for a newer Daemonitor installer. Nothing is installed without approval."
+        UpdateUiState.Checking -> "Checking GitHub Releases..."
+        is UpdateUiState.UpToDate -> "Daemonitor is up to date at v$version."
+        is UpdateUiState.Available -> "v${candidate.version} is available. ${candidate.assetName} will open only if you approve."
+        is UpdateUiState.Failed -> message
+    }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -1,16 +1,35 @@
 package io.github.cdsap.daemonitor.ui.settings
 
+import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
+import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import io.github.cdsap.daemonitor.update.UpdateCandidate
+import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstaller
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 /** Immutable state the Settings screen renders. */
 data class SettingsUiState(
     val retentionDays: Long = Defaults.DEFAULT_RETENTION_DAYS,
     val appearance: AppearancePreference = AppearancePreference.SYSTEM,
+    val updateState: UpdateUiState = UpdateUiState.NotChecked,
 )
+
+sealed interface UpdateUiState {
+    data object NotChecked : UpdateUiState
+    data object Checking : UpdateUiState
+    data class UpToDate(val version: String) : UpdateUiState
+    data class Available(val candidate: UpdateCandidate) : UpdateUiState
+    data class Failed(val message: String) : UpdateUiState
+}
 
 /**
  * Holds Settings state and forwards changes to [onRetentionChange], which the service wires to
@@ -20,6 +39,11 @@ class SettingsViewModel(
     initial: SettingsUiState = SettingsUiState(),
     private val onRetentionChange: (Long) -> Unit = {},
     private val onAppearanceChange: (AppearancePreference) -> Unit = {},
+    private val updateChecker: suspend () -> UpdateCheckResult = {
+        GitHubReleaseUpdateSource().check(BuildInfo.current.version)
+    },
+    private val updateInstaller: UpdateInstaller = DesktopUpdateInstaller(),
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
 ) {
     private val _state = MutableStateFlow(initial)
     val state: StateFlow<SettingsUiState> = _state.asStateFlow()
@@ -35,5 +59,31 @@ class SettingsViewModel(
         if (appearance == _state.value.appearance) return
         _state.value = _state.value.copy(appearance = appearance)
         onAppearanceChange(appearance)
+    }
+
+    fun checkForUpdates() {
+        if (_state.value.updateState == UpdateUiState.Checking) return
+        _state.value = _state.value.copy(updateState = UpdateUiState.Checking)
+        scope.launch {
+            _state.value = _state.value.copy(updateState = updateChecker().toUiState())
+        }
+    }
+
+    fun openUpdate(candidate: UpdateCandidate) {
+        runCatching { updateInstaller.open(candidate) }
+            .onFailure { error ->
+                _state.value = _state.value.copy(
+                    updateState = UpdateUiState.Failed(
+                        error.message ?: error::class.simpleName ?: "Could not open the update",
+                    ),
+                )
+            }
+    }
+
+    private fun UpdateCheckResult.toUiState(): UpdateUiState = when (this) {
+        is UpdateCheckResult.Available -> UpdateUiState.Available(candidate)
+        is UpdateCheckResult.UpToDate -> UpdateUiState.UpToDate(currentVersion)
+        is UpdateCheckResult.UnsupportedPlatform -> UpdateUiState.Failed("Updates are not available for this platform yet")
+        is UpdateCheckResult.Failed -> UpdateUiState.Failed(reason)
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatform.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatform.kt
@@ -1,0 +1,21 @@
+package io.github.cdsap.daemonitor.update
+
+enum class DesktopPlatform(val assetSuffix: String) {
+    MACOS("-macos.dmg"),
+    WINDOWS("-windows.msi"),
+    LINUX("-linux.deb"),
+    UNKNOWN(""),
+    ;
+
+    companion object {
+        fun current(osName: String = System.getProperty("os.name")): DesktopPlatform {
+            val normalized = osName.lowercase()
+            return when {
+                normalized.contains("mac") || normalized.contains("darwin") -> MACOS
+                normalized.contains("win") -> WINDOWS
+                normalized.contains("linux") -> LINUX
+                else -> UNKNOWN
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
@@ -1,0 +1,97 @@
+package io.github.cdsap.daemonitor.update
+
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class GitHubReleaseUpdateSource(
+    private val repository: String = "cdsap/daemonitor",
+    private val platform: DesktopPlatform = DesktopPlatform.current(),
+    private val client: HttpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build(),
+) {
+    suspend fun check(currentVersion: String): UpdateCheckResult = withContext(Dispatchers.IO) {
+        if (platform == DesktopPlatform.UNKNOWN) {
+            return@withContext UpdateCheckResult.UnsupportedPlatform(platform)
+        }
+
+        runCatching {
+            val request = HttpRequest.newBuilder()
+                .uri(URI("https://api.github.com/repos/$repository/releases/latest"))
+                .header("Accept", "application/vnd.github+json")
+                .header("User-Agent", "Daemonitor")
+                .GET()
+                .build()
+            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+            if (response.statusCode() !in 200..299) {
+                return@withContext UpdateCheckResult.Failed("GitHub returned HTTP ${response.statusCode()}")
+            }
+            val release = GitHubReleaseJsonParser.parse(response.body())
+                ?: return@withContext UpdateCheckResult.Failed("Could not read the latest release metadata")
+            ReleaseUpdateSelector.select(release, currentVersion, platform)
+        }.getOrElse { error ->
+            UpdateCheckResult.Failed(error.message ?: error::class.simpleName ?: "Update check failed")
+        }
+    }
+}
+
+internal data class GitHubRelease(
+    val version: String,
+    val releaseUrl: String,
+    val assets: List<GitHubReleaseAsset>,
+)
+
+internal data class GitHubReleaseAsset(val name: String, val downloadUrl: String)
+
+internal object ReleaseUpdateSelector {
+    fun select(
+        release: GitHubRelease,
+        currentVersion: String,
+        platform: DesktopPlatform,
+    ): UpdateCheckResult {
+        val asset = release.assets.firstOrNull { it.name.endsWith(platform.assetSuffix) }
+            ?: return UpdateCheckResult.Failed("No ${platform.name.lowercase()} installer was attached to ${release.version}")
+
+        return if (VersionComparator.isNewer(release.version, currentVersion)) {
+            UpdateCheckResult.Available(
+                UpdateCandidate(
+                    version = release.version.removePrefix("v").removePrefix("V"),
+                    releaseUrl = release.releaseUrl,
+                    assetName = asset.name,
+                    downloadUrl = asset.downloadUrl,
+                ),
+            )
+        } else {
+            UpdateCheckResult.UpToDate(currentVersion)
+        }
+    }
+}
+
+internal object GitHubReleaseJsonParser {
+    private val tagPattern = Regex(""""tag_name"\s*:\s*"([^"]+)"""")
+    private val releaseUrlPattern = Regex(""""html_url"\s*:\s*"([^"]+)"""")
+    private val assetPattern = Regex(
+        """"name"\s*:\s*"([^"]+)".*?"browser_download_url"\s*:\s*"([^"]+)"""",
+        setOf(RegexOption.DOT_MATCHES_ALL),
+    )
+
+    fun parse(json: String): GitHubRelease? {
+        val version = tagPattern.find(json)?.groupValues?.get(1) ?: return null
+        val releaseUrl = releaseUrlPattern.find(json)?.groupValues?.get(1) ?: return null
+        val assetsJson = json.substringAfter(""""assets"""", missingDelimiterValue = "")
+        val assets = assetPattern.findAll(assetsJson).map { match ->
+            GitHubReleaseAsset(
+                name = match.groupValues[1].jsonUnescape(),
+                downloadUrl = match.groupValues[2].jsonUnescape(),
+            )
+        }.toList()
+        return GitHubRelease(version = version, releaseUrl = releaseUrl.jsonUnescape(), assets = assets)
+    }
+
+    private fun String.jsonUnescape(): String =
+        replace("\\/", "/")
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
@@ -1,0 +1,15 @@
+package io.github.cdsap.daemonitor.update
+
+data class UpdateCandidate(
+    val version: String,
+    val releaseUrl: String,
+    val assetName: String,
+    val downloadUrl: String,
+)
+
+sealed interface UpdateCheckResult {
+    data class Available(val candidate: UpdateCandidate) : UpdateCheckResult
+    data class UpToDate(val currentVersion: String) : UpdateCheckResult
+    data class UnsupportedPlatform(val platform: DesktopPlatform) : UpdateCheckResult
+    data class Failed(val reason: String) : UpdateCheckResult
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
@@ -1,0 +1,17 @@
+package io.github.cdsap.daemonitor.update
+
+import java.awt.Desktop
+import java.net.URI
+
+fun interface UpdateInstaller {
+    fun open(candidate: UpdateCandidate)
+}
+
+class DesktopUpdateInstaller : UpdateInstaller {
+    override fun open(candidate: UpdateCandidate) {
+        require(Desktop.isDesktopSupported()) { "Desktop integration is not available" }
+        val desktop = Desktop.getDesktop()
+        require(desktop.isSupported(Desktop.Action.BROWSE)) { "Opening update downloads is not supported" }
+        desktop.browse(URI(candidate.downloadUrl))
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/VersionComparator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/VersionComparator.kt
@@ -1,0 +1,26 @@
+package io.github.cdsap.daemonitor.update
+
+object VersionComparator {
+    fun isNewer(candidate: String, current: String): Boolean =
+        compare(candidate, current) > 0
+
+    fun compare(left: String, right: String): Int {
+        val leftParts = left.versionParts()
+        val rightParts = right.versionParts()
+        val maxSize = maxOf(leftParts.size, rightParts.size)
+        for (index in 0 until maxSize) {
+            val leftPart = leftParts.getOrElse(index) { 0 }
+            val rightPart = rightParts.getOrElse(index) { 0 }
+            if (leftPart != rightPart) return leftPart.compareTo(rightPart)
+        }
+        return 0
+    }
+
+    private fun String.versionParts(): List<Int> =
+        trim()
+            .removePrefix("v")
+            .removePrefix("V")
+            .substringBefore("-")
+            .split(".")
+            .mapNotNull { it.toIntOrNull() }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.update.UpdateCandidate
 import io.github.cdsap.daemonitor.ui.common.WatcherTheme
 import io.github.cdsap.daemonitor.ui.common.WatcherDarkColors
 import io.github.cdsap.daemonitor.ui.common.WatcherLightColors
@@ -69,5 +70,47 @@ class SettingsScreenUiTest {
         onNodeWithText("Keep build & process history for").assertExists()
         assertEquals(AppearancePreference.DARK, picked)
         assertEquals(WatcherDarkColors.background, renderedBackground)
+    }
+
+    @Test
+    fun `update card can trigger a manual check`() = runComposeUiTest {
+        var checks = 0
+        setContent {
+            WatcherTheme {
+                SettingsScreen(
+                    SettingsUiState(),
+                    onRetentionDays = {},
+                    onCheckForUpdates = { checks += 1 },
+                )
+            }
+        }
+
+        onNodeWithText("Check for updates").performClick()
+
+        assertEquals(1, checks)
+    }
+
+    @Test
+    fun `available update renders installer action`() = runComposeUiTest {
+        var opened: UpdateCandidate? = null
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-macos.dmg",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+        )
+        setContent {
+            WatcherTheme {
+                SettingsScreen(
+                    SettingsUiState(updateState = UpdateUiState.Available(candidate)),
+                    onRetentionDays = {},
+                    onOpenUpdate = { opened = it },
+                )
+            }
+        }
+
+        onNodeWithText("Open installer").performClick()
+
+        assertEquals(candidate, opened)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -2,6 +2,13 @@ package io.github.cdsap.daemonitor.ui.settings
 
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.update.UpdateCandidate
+import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstaller
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -43,4 +50,68 @@ class SettingsViewModelTest {
         assertEquals(AppearancePreference.DARK, vm.state.value.appearance)
         assertEquals(listOf(AppearancePreference.DARK), changes)
     }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `checking for updates exposes available update state`() = runTest {
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-macos.dmg",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+        )
+        val vm = updateViewModel(
+            result = UpdateCheckResult.Available(candidate),
+            scope = this,
+        )
+
+        vm.checkForUpdates()
+        advanceUntilIdle()
+
+        assertEquals(UpdateUiState.Available(candidate), vm.state.value.updateState)
+    }
+
+    @Test
+    fun `opening an available update delegates to installer`() {
+        val opened = mutableListOf<UpdateCandidate>()
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-linux.deb",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-linux.deb",
+        )
+        val vm = SettingsViewModel(
+            updateInstaller = UpdateInstaller { opened += it },
+        )
+
+        vm.openUpdate(candidate)
+
+        assertEquals(listOf(candidate), opened)
+    }
+
+    @Test
+    fun `installer failures are surfaced in update state`() {
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-windows.msi",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-windows.msi",
+        )
+        val vm = SettingsViewModel(
+            updateInstaller = UpdateInstaller { error("No desktop") },
+        )
+
+        vm.openUpdate(candidate)
+
+        assertEquals(UpdateUiState.Failed("No desktop"), vm.state.value.updateState)
+    }
+
+    private fun updateViewModel(
+        result: UpdateCheckResult,
+        scope: TestScope,
+    ): SettingsViewModel = SettingsViewModel(
+        updateChecker = { result },
+        updateInstaller = UpdateInstaller {},
+        scope = scope,
+    )
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatformTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatformTest.kt
@@ -1,0 +1,15 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopPlatformTest {
+
+    @Test
+    fun `maps common os names to release asset suffixes`() {
+        assertEquals(DesktopPlatform.MACOS, DesktopPlatform.current("Mac OS X"))
+        assertEquals(DesktopPlatform.WINDOWS, DesktopPlatform.current("Windows 11"))
+        assertEquals(DesktopPlatform.LINUX, DesktopPlatform.current("Linux"))
+        assertEquals(DesktopPlatform.UNKNOWN, DesktopPlatform.current("Solaris"))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseJsonParserTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseJsonParserTest.kt
@@ -1,0 +1,44 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GitHubReleaseJsonParserTest {
+
+    @Test
+    fun `parses release tag url and assets`() {
+        val release = GitHubReleaseJsonParser.parse(
+            """
+            {
+              "tag_name": "v1.0.3",
+              "name": "v1.0.3",
+              "html_url": "https://github.com/cdsap/daemonitor/releases/tag/v1.0.3",
+              "assets": [
+                {
+                  "name": "Daemonitor-1.0.3-linux.deb",
+                  "browser_download_url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.3/Daemonitor-1.0.3-linux.deb"
+                },
+                {
+                  "name": "Daemonitor-1.0.3-macos.dmg",
+                  "browser_download_url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.3/Daemonitor-1.0.3-macos.dmg"
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        requireNotNull(release)
+        assertEquals("v1.0.3", release.version)
+        assertEquals("https://github.com/cdsap/daemonitor/releases/tag/v1.0.3", release.releaseUrl)
+        assertEquals(
+            listOf("Daemonitor-1.0.3-linux.deb", "Daemonitor-1.0.3-macos.dmg"),
+            release.assets.map { it.name },
+        )
+    }
+
+    @Test
+    fun `returns null when required release metadata is absent`() {
+        assertNull(GitHubReleaseJsonParser.parse("""{"assets": []}"""))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateSelectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateSelectorTest.kt
@@ -1,0 +1,56 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class ReleaseUpdateSelectorTest {
+
+    @Test
+    fun `selects matching platform asset when release is newer`() {
+        val result = ReleaseUpdateSelector.select(
+            release = release("v1.0.3"),
+            currentVersion = "1.0.2",
+            platform = DesktopPlatform.MACOS,
+        )
+
+        val available = assertIs<UpdateCheckResult.Available>(result)
+        assertEquals("1.0.3", available.candidate.version)
+        assertEquals("Daemonitor-1.0.3-macos.dmg", available.candidate.assetName)
+        assertEquals("https://example.com/Daemonitor-1.0.3-macos.dmg", available.candidate.downloadUrl)
+    }
+
+    @Test
+    fun `reports up to date when latest release is not newer`() {
+        val result = ReleaseUpdateSelector.select(
+            release = release("v1.0.2"),
+            currentVersion = "1.0.2",
+            platform = DesktopPlatform.WINDOWS,
+        )
+
+        assertEquals(UpdateCheckResult.UpToDate("1.0.2"), result)
+    }
+
+    @Test
+    fun `fails when release does not include a matching installer`() {
+        val result = ReleaseUpdateSelector.select(
+            release = release("v1.0.3"),
+            currentVersion = "1.0.2",
+            platform = DesktopPlatform.LINUX,
+        )
+
+        assertEquals(
+            UpdateCheckResult.Failed("No linux installer was attached to v1.0.3"),
+            result,
+        )
+    }
+
+    private fun release(version: String): GitHubRelease = GitHubRelease(
+        version = version,
+        releaseUrl = "https://example.com/release",
+        assets = listOf(
+            GitHubReleaseAsset("Daemonitor-${version.removePrefix("v")}-macos.dmg", "https://example.com/Daemonitor-${version.removePrefix("v")}-macos.dmg"),
+            GitHubReleaseAsset("Daemonitor-${version.removePrefix("v")}-windows.msi", "https://example.com/Daemonitor-${version.removePrefix("v")}-windows.msi"),
+        ),
+    )
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/VersionComparatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/VersionComparatorTest.kt
@@ -1,0 +1,26 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class VersionComparatorTest {
+
+    @Test
+    fun `detects newer semantic versions with optional v prefix`() {
+        assertTrue(VersionComparator.isNewer("v1.0.3", "1.0.2"))
+        assertTrue(VersionComparator.isNewer("1.1.0", "1.0.9"))
+    }
+
+    @Test
+    fun `does not report same or older versions as newer`() {
+        assertFalse(VersionComparator.isNewer("v1.0.2", "1.0.2"))
+        assertFalse(VersionComparator.isNewer("1.0.1", "1.0.2"))
+    }
+
+    @Test
+    fun `compares missing patch values as zero`() {
+        assertFalse(VersionComparator.isNewer("1.0", "1.0.0"))
+        assertTrue(VersionComparator.isNewer("1.0.1", "1.0"))
+    }
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 update support from issue #49:

- adds a GitHub Releases update checker for the latest Daemonitor release
- compares release tags with the running `BuildInfo` version
- selects the matching native installer asset for macOS, Windows, or Linux
- adds an Updates card in Settings with manual check and approved installer-open actions
- adds `java.net.http` to the packaged runtime modules
- documents the check-and-open update behavior in the README

Follow-up issues created:

- #50 Publish update metadata and checksums with releases
- #51 Evaluate native auto-update integrations for macOS and Windows
- #52 Design Linux update distribution beyond direct deb downloads

Fixes #49.

## Validation

- `./gradlew test --no-daemon --stacktrace`
- `./gradlew createDistributable packageDmg --no-daemon --stacktrace`
- `build/compose/binaries/main/app/Daemonitor.app/Contents/MacOS/Daemonitor --headless --help`
- `jimage list --include 'regex:/java.net.http/module-info.class' build/compose/binaries/main/app/Daemonitor.app/Contents/runtime/Contents/Home/lib/modules`
- `git diff --check`
