### PR TITLE
Check for updates on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ triggered each build**. It's built for the agentic-workflow era, where multiple 
 agents can all be driving Gradle at once.
 
 Everything stays on your machine. No telemetry; command lines and logs are best-effort redacted
-before they're ever stored. The only outbound request is an explicit Settings check for GitHub
-Releases updates.
+before they're ever stored. The only outbound request is a GitHub Releases update check at startup
+and when you ask from Settings.
 
 [![CI](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)
@@ -99,7 +99,8 @@ apt repository with advisory in-app prompts only; see
 
 ## Updates
 
-The Settings tab can check GitHub Releases for a newer Daemonitor version. When a newer release is
+Daemonitor checks GitHub Releases once at startup and marks the Settings tab as `Settings (1)` when
+a newer version is available. The Settings tab can also check manually. When a newer release is
 available, Daemonitor shows the matching installer for the current operating system and opens the
 download only after you approve it. The app does not silently install updates.
 
@@ -193,7 +194,7 @@ Kotlin · Compose for Desktop (Material 3) · OSHI · SQLDelight + JDBC SQLite �
 All data is local. Command lines and daemon-log lines may contain sensitive values, so they are
 redacted on a best-effort basis before storage, and the database file is created with owner-only
 permissions. Daemonitor only makes an outbound request when you explicitly check GitHub Releases for
-updates from Settings.
+updates from Settings or when it checks GitHub Releases at startup.
 
 ## Status
 

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -93,6 +93,7 @@ internal fun DaemonitorContent(
             val liveState by service.liveViewModel.state.collectAsState()
             AppScaffold(
                 onSwitchToHeadless = onSwitchToHeadless,
+                settingsNotificationCount = settingsState.updateNotificationCount,
                 liveContent = {
                     LiveMonitorScreen(
                         state = liveState,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -8,6 +8,8 @@ import io.github.cdsap.daemonitor.ui.history.HistoryViewModel
 import io.github.cdsap.daemonitor.ui.live.LiveViewModel
 import io.github.cdsap.daemonitor.ui.settings.SettingsUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsViewModel
+import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import io.github.cdsap.daemonitor.update.UpdateCheckResult
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
@@ -23,6 +25,9 @@ class WatcherService(
     private val settingsStore: SettingsStore = SettingsStore(),
     private val clock: () -> Long = System::currentTimeMillis,
     private val pollAction: suspend () -> WatcherRuntime.PollResult = { runtime.pollOnce() },
+    private val updateChecker: suspend () -> UpdateCheckResult = {
+        GitHubReleaseUpdateSource().check(BuildInfo.current.version)
+    },
 ) {
     val liveViewModel = LiveViewModel()
     val historyViewModel = HistoryViewModel()
@@ -35,11 +40,13 @@ class WatcherService(
         initial = SettingsUiState(retentionDays = retentionDays, appearance = initialSettings.appearance),
         onRetentionChange = ::onRetentionChanged,
         onAppearanceChange = ::onAppearanceChanged,
+        updateChecker = updateChecker,
     )
 
     private var serviceScope: CoroutineScope? = null
     fun start(scope: CoroutineScope) {
         serviceScope = scope
+        settingsViewModel.checkForUpdates()
         database.purgeOlderThan(clock(), retentionDays)
         // Load whatever history already exists, then keep it current from the poll loop.
         scope.launch(Dispatchers.IO) { refreshHistory() }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
@@ -47,6 +47,7 @@ fun AppScaffold(
     historyContent: @Composable () -> Unit,
     settingsContent: @Composable () -> Unit,
     onSwitchToHeadless: () -> Unit = {},
+    settingsNotificationCount: Int = 0,
     buildInfo: BuildInfo = BuildInfo.current,
 ) {
     var selectedTab by remember { mutableStateOf(0) }
@@ -56,6 +57,7 @@ fun AppScaffold(
             selectedTab = selectedTab,
             onSelectTab = { selectedTab = it },
             onSwitchToHeadless = onSwitchToHeadless,
+            settingsNotificationCount = settingsNotificationCount,
         )
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         Column(modifier = Modifier.weight(1f)) {
@@ -76,6 +78,7 @@ private fun AppHeader(
     selectedTab: Int,
     onSelectTab: (Int) -> Unit,
     onSwitchToHeadless: () -> Unit,
+    settingsNotificationCount: Int,
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -111,7 +114,7 @@ private fun AppHeader(
                         label = {
                             Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
                                 Icon(item.icon, contentDescription = null, modifier = Modifier.size(15.dp))
-                                Text(item.label)
+                                Text(item.label(settingsNotificationCount))
                             }
                         },
                     )
@@ -148,7 +151,14 @@ private fun AppHeader(
     }
 }
 
-private data class NavItem(val label: String, val icon: ImageVector)
+private data class NavItem(val label: String, val icon: ImageVector) {
+    fun label(settingsNotificationCount: Int): String =
+        if (label == "Settings" && settingsNotificationCount > 0) {
+            "$label ($settingsNotificationCount)"
+        } else {
+            label
+        }
+}
 
 private val NAV_ITEMS = listOf(
     NavItem("Live", Icons.Filled.Speed),

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -21,7 +21,10 @@ data class SettingsUiState(
     val retentionDays: Long = Defaults.DEFAULT_RETENTION_DAYS,
     val appearance: AppearancePreference = AppearancePreference.SYSTEM,
     val updateState: UpdateUiState = UpdateUiState.NotChecked,
-)
+) {
+    val updateNotificationCount: Int
+        get() = if (updateState is UpdateUiState.Available) 1 else 0
+}
 
 sealed interface UpdateUiState {
     data object NotChecked : UpdateUiState
@@ -65,7 +68,13 @@ class SettingsViewModel(
         if (_state.value.updateState == UpdateUiState.Checking) return
         _state.value = _state.value.copy(updateState = UpdateUiState.Checking)
         scope.launch {
-            _state.value = _state.value.copy(updateState = updateChecker().toUiState())
+            val nextState = runCatching { updateChecker().toUiState() }
+                .getOrElse { error ->
+                    UpdateUiState.Failed(
+                        error.message ?: error::class.simpleName ?: "Could not check for updates",
+                    )
+                }
+            _state.value = _state.value.copy(updateState = nextState)
         }
     }
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -2,9 +2,12 @@ package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
+import io.github.cdsap.daemonitor.ui.settings.UpdateUiState
+import io.github.cdsap.daemonitor.update.UpdateCheckResult
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
@@ -86,10 +89,39 @@ class WatcherServiceTest {
         }
     }
 
+    @Test
+    fun `starting service checks for updates`(@TempDir tmp: Path) = runTest {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        try {
+            var updateChecks = 0
+            val service = service(
+                database = database,
+                tmp = tmp,
+                updateChecker = {
+                    updateChecks += 1
+                    UpdateCheckResult.UpToDate("1.0.3")
+                },
+            ) {
+                WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
+            }
+
+            service.start(backgroundScope)
+            advanceUntilIdle()
+
+            assertEquals(1, updateChecks)
+            assertEquals(UpdateUiState.UpToDate("1.0.3"), service.settingsViewModel.state.value.updateState)
+        } finally {
+            Dispatchers.resetMain()
+            database.close()
+        }
+    }
+
     private fun service(
         database: WatcherDatabase,
         tmp: Path,
         clock: () -> Long = { 0 },
+        updateChecker: suspend () -> UpdateCheckResult = { UpdateCheckResult.UpToDate("1.0.3") },
         pollAction: suspend () -> WatcherRuntime.PollResult,
     ) = WatcherService(
         runtime = WatcherRuntime.create(database),
@@ -97,5 +129,6 @@ class WatcherServiceTest {
         settingsStore = SettingsStore(tmp.resolve("settings.properties")),
         clock = clock,
         pollAction = pollAction,
+        updateChecker = updateChecker,
     )
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
@@ -63,6 +63,22 @@ class AppScaffoldUiTest {
     }
 
     @Test
+    fun `settings tab shows notification count when an update is available`() = runComposeUiTest {
+        setContent {
+            WatcherTheme {
+                AppScaffold(
+                    settingsNotificationCount = 1,
+                    liveContent = { Text("Live") },
+                    historyContent = { Text("History") },
+                    settingsContent = { Text("Settings") },
+                )
+            }
+        }
+
+        onNodeWithText("Settings (1)").assertExists()
+    }
+
+    @Test
     fun `header exposes switch to headless action`() = runComposeUiTest {
         var switchedToHeadless = false
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -69,6 +69,23 @@ class SettingsViewModelTest {
         advanceUntilIdle()
 
         assertEquals(UpdateUiState.Available(candidate), vm.state.value.updateState)
+        assertEquals(1, vm.state.value.updateNotificationCount)
+    }
+
+    @Test
+    fun `update notification count is only set for available updates`() {
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-macos.dmg",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+        )
+
+        assertEquals(0, SettingsUiState().updateNotificationCount)
+        assertEquals(0, SettingsUiState(updateState = UpdateUiState.Checking).updateNotificationCount)
+        assertEquals(0, SettingsUiState(updateState = UpdateUiState.UpToDate("1.0.2")).updateNotificationCount)
+        assertEquals(0, SettingsUiState(updateState = UpdateUiState.Failed("No network")).updateNotificationCount)
+        assertEquals(1, SettingsUiState(updateState = UpdateUiState.Available(candidate)).updateNotificationCount)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- check GitHub Releases when the desktop service starts
- show Settings (1) when a startup/manual check finds an available update
- document the startup update check in README privacy/update sections

## Tests
- ./gradlew test --no-daemon --stacktrace --tests io.github.cdsap.daemonitor.ui.common.AppScaffoldUiTest --tests io.github.cdsap.daemonitor.ui.settings.SettingsViewModelTest --tests io.github.cdsap.daemonitor.WatcherServiceTest
- ./gradlew test --no-daemon --stacktrace