### PR TITLE
Download verified updates in app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ triggered each build**. It's built for the agentic-workflow era, where multiple 
 agents can all be driving Gradle at once.
 
 Everything stays on your machine. No telemetry; command lines and logs are best-effort redacted
-before they're ever stored. The only outbound request is a GitHub Releases update check at startup
-and when you ask from Settings.
+before they're ever stored. Outbound network use is limited to GitHub Releases update checks at
+startup or from Settings, plus installer downloads that you explicitly approve.
 
 [![CI](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)
@@ -101,8 +101,9 @@ apt repository with advisory in-app prompts only; see
 
 Daemonitor checks GitHub Releases once at startup and marks the Settings tab as `Settings (1)` when
 a newer version is available. The Settings tab can also check manually. When a newer release is
-available, Daemonitor shows the matching installer for the current operating system and opens the
-download only after you approve it. The app does not silently install updates.
+available, Daemonitor downloads the matching installer for the current operating system only after
+you approve it, verifies the SHA-256 checksum from release metadata, and opens the local installer.
+The app does not silently install updates.
 
 ## Run from source
 
@@ -193,8 +194,8 @@ Kotlin · Compose for Desktop (Material 3) · OSHI · SQLDelight + JDBC SQLite �
 
 All data is local. Command lines and daemon-log lines may contain sensitive values, so they are
 redacted on a best-effort basis before storage, and the database file is created with owner-only
-permissions. Daemonitor only makes an outbound request when you explicitly check GitHub Releases for
-updates from Settings or when it checks GitHub Releases at startup.
+permissions. Daemonitor only makes outbound requests for GitHub Releases update checks at startup or
+from Settings, and for installer downloads that you explicitly approve.
 
 ## Status
 

--- a/docs/linux-update-distribution.md
+++ b/docs/linux-update-distribution.md
@@ -11,8 +11,8 @@ available version and send the user to the appropriate system-managed install pa
 
 - If the current install came from the apt repository, prompt the user to update through their
   package manager.
-- If the current install came from a downloaded `.deb`, prompt the user to download/open the newer
-  GitHub Releases `.deb`.
+- If the current install came from a downloaded `.deb`, prompt the user to download and open the
+  newer GitHub Releases `.deb`.
 - If the install source is unknown, offer both paths and explain that apt is preferred once the
   repository is configured.
 
@@ -51,8 +51,8 @@ Linux prompts must be advisory, not self-installing:
 - Show the available version and release link.
 - Never run `sudo`, `pkexec`, `apt`, `dpkg`, or any privileged installer command from the app.
 - For apt installs, say to update from the system package manager and link to repository setup docs.
-- For direct `.deb` installs, offer the GitHub Releases `.deb` and let the OS package installer
-  handle privilege prompts.
+- For direct `.deb` installs, the app may download and verify the GitHub Releases `.deb`, then open
+  it with the OS package installer so the operating system owns privilege prompts.
 - Allow dismissing or deferring the prompt so background collection is not blocked.
 
 ## Package Metadata Requirements

--- a/docs/update-metadata.md
+++ b/docs/update-metadata.md
@@ -1,7 +1,9 @@
 # Update Metadata Contract
 
 Daemonitor publishes update metadata to each tag-triggered GitHub Release so updater clients can
-validate release information and native downloads before presenting or opening installers.
+validate release information and native downloads before presenting or opening installers. The
+desktop app uses this metadata to download the selected installer in-app, verify it, and then hand
+off to the operating system installer.
 
 ## Release assets
 
@@ -56,8 +58,8 @@ Updater clients should:
 2. Confirm `schemaVersion` is supported.
 3. Select the asset matching the current platform.
 4. Download the asset from `url`.
-5. Compute SHA-256 over the downloaded bytes and compare it with `sha256` before presenting or
-   opening the installer.
+5. Compute SHA-256 over the downloaded bytes and compare it with `sha256`.
+6. Open the verified local installer only after the user approves the update.
 
 Clients may also download `checksums.txt` and compare it against the JSON asset list as a secondary
 integrity check.

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.SystemUpdate
 import androidx.compose.material3.Button
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
@@ -98,6 +99,14 @@ fun SettingsScreen(
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
+                val downloading = state.updateState as? UpdateUiState.Downloading
+                if (downloading != null) {
+                    Spacer(Modifier.height(Space.sm))
+                    LinearProgressIndicator(
+                        progress = { downloading.progress?.coerceIn(0.0, 1.0)?.toFloat() ?: 0f },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
                 Spacer(Modifier.height(Space.md))
                 Row(horizontalArrangement = Arrangement.spacedBy(Space.sm), verticalAlignment = Alignment.CenterVertically) {
                     OutlinedButton(
@@ -110,14 +119,17 @@ fun SettingsScreen(
                         Text(if (state.updateState == UpdateUiState.Checking) "Checking" else "Check for updates")
                     }
                     val available = state.updateState as? UpdateUiState.Available
-                    if (available != null) {
+                    val ready = state.updateState as? UpdateUiState.ReadyToInstall
+                    val candidate = available?.candidate ?: ready?.candidate
+                    if (candidate != null) {
                         Button(
-                            onClick = { onOpenUpdate(available.candidate) },
+                            onClick = { onOpenUpdate(candidate) },
+                            enabled = state.updateState !is UpdateUiState.Downloading,
                             shape = RoundedCornerShape(Radius.sm),
                         ) {
                             Icon(Icons.Filled.Download, contentDescription = null)
                             Spacer(Modifier.width(Space.xs))
-                            Text("Open installer")
+                            Text(if (ready != null) "Open again" else "Download and open")
                         }
                     }
                 }
@@ -174,6 +186,9 @@ private val UpdateUiState.message: String
         UpdateUiState.NotChecked -> "Check GitHub Releases for a newer Daemonitor installer. Nothing is installed without approval."
         UpdateUiState.Checking -> "Checking GitHub Releases..."
         is UpdateUiState.UpToDate -> "Daemonitor is up to date at v$version."
-        is UpdateUiState.Available -> "v${candidate.version} is available. ${candidate.assetName} will open only if you approve."
+        is UpdateUiState.Available -> "v${candidate.version} is available. Daemonitor will download and verify ${candidate.assetName} before opening it."
+        is UpdateUiState.Downloading -> progress?.let { "Downloading ${candidate.assetName}: ${(it * 100).toInt()}%." }
+            ?: "Downloading ${candidate.assetName}..."
+        is UpdateUiState.ReadyToInstall -> "Downloaded and opened ${candidate.assetName}. Finish the installer to update Daemonitor."
         is UpdateUiState.Failed -> message
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -23,7 +23,12 @@ data class SettingsUiState(
     val updateState: UpdateUiState = UpdateUiState.NotChecked,
 ) {
     val updateNotificationCount: Int
-        get() = if (updateState is UpdateUiState.Available) 1 else 0
+        get() = when (updateState) {
+            is UpdateUiState.Available,
+            is UpdateUiState.Downloading,
+            is UpdateUiState.ReadyToInstall -> 1
+            else -> 0
+        }
 }
 
 sealed interface UpdateUiState {
@@ -31,6 +36,8 @@ sealed interface UpdateUiState {
     data object Checking : UpdateUiState
     data class UpToDate(val version: String) : UpdateUiState
     data class Available(val candidate: UpdateCandidate) : UpdateUiState
+    data class Downloading(val candidate: UpdateCandidate, val progress: Double?) : UpdateUiState
+    data class ReadyToInstall(val candidate: UpdateCandidate) : UpdateUiState
     data class Failed(val message: String) : UpdateUiState
 }
 
@@ -79,14 +86,23 @@ class SettingsViewModel(
     }
 
     fun openUpdate(candidate: UpdateCandidate) {
-        runCatching { updateInstaller.open(candidate) }
-            .onFailure { error ->
+        if (_state.value.updateState is UpdateUiState.Downloading) return
+        _state.value = _state.value.copy(updateState = UpdateUiState.Downloading(candidate, 0.0))
+        scope.launch {
+            runCatching {
+                updateInstaller.open(candidate) { progress ->
+                    _state.value = _state.value.copy(updateState = UpdateUiState.Downloading(candidate, progress))
+                }
+            }.onSuccess {
+                _state.value = _state.value.copy(updateState = UpdateUiState.ReadyToInstall(candidate))
+            }.onFailure { error ->
                 _state.value = _state.value.copy(
                     updateState = UpdateUiState.Failed(
                         error.message ?: error::class.simpleName ?: "Could not open the update",
                     ),
                 )
             }
+        }
     }
 
     private fun UpdateCheckResult.toUiState(): UpdateUiState = when (this) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
@@ -30,10 +30,33 @@ class GitHubReleaseUpdateSource(
             }
             val release = GitHubReleaseJsonParser.parse(response.body())
                 ?: return@withContext UpdateCheckResult.Failed("Could not read the latest release metadata")
-            ReleaseUpdateSelector.select(release, currentVersion, platform)
+            val metadata = release.updateMetadataAsset()?.let { asset ->
+                fetchUpdateMetadata(asset.downloadUrl)
+            }
+            if (metadata != null) {
+                ReleaseMetadataUpdateSelector.select(metadata, release.releaseUrl, currentVersion, platform)
+            } else {
+                ReleaseUpdateSelector.select(release, currentVersion, platform)
+            }
         }.getOrElse { error ->
             UpdateCheckResult.Failed(error.message ?: error::class.simpleName ?: "Update check failed")
         }
+    }
+
+    private fun GitHubRelease.updateMetadataAsset(): GitHubReleaseAsset? =
+        assets.firstOrNull { it.name == "update.json" }
+            ?: assets.firstOrNull { it.name == "latest.json" }
+
+    private fun fetchUpdateMetadata(url: String): ReleaseUpdateMetadata? {
+        val request = HttpRequest.newBuilder()
+            .uri(URI(url))
+            .header("Accept", "application/json")
+            .header("User-Agent", "Daemonitor")
+            .GET()
+            .build()
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in 200..299) return null
+        return ReleaseUpdateMetadataJsonParser.parse(response.body())
     }
 }
 
@@ -44,6 +67,55 @@ internal data class GitHubRelease(
 )
 
 internal data class GitHubReleaseAsset(val name: String, val downloadUrl: String)
+
+internal data class ReleaseUpdateMetadata(
+    val version: String,
+    val tag: String,
+    val assets: List<ReleaseUpdateAsset>,
+)
+
+internal data class ReleaseUpdateAsset(
+    val platform: String,
+    val fileName: String,
+    val url: String,
+    val sha256: String,
+    val sizeBytes: Long,
+)
+
+internal object ReleaseMetadataUpdateSelector {
+    fun select(
+        metadata: ReleaseUpdateMetadata,
+        releaseUrl: String,
+        currentVersion: String,
+        platform: DesktopPlatform,
+    ): UpdateCheckResult {
+        val asset = metadata.assets.firstOrNull { it.platform == platform.metadataName }
+            ?: return UpdateCheckResult.Failed("No ${platform.name.lowercase()} installer was listed in ${metadata.tag}")
+
+        return if (VersionComparator.isNewer(metadata.version, currentVersion)) {
+            UpdateCheckResult.Available(
+                UpdateCandidate(
+                    version = metadata.version,
+                    releaseUrl = releaseUrl,
+                    assetName = asset.fileName,
+                    downloadUrl = asset.url,
+                    sha256 = asset.sha256,
+                    sizeBytes = asset.sizeBytes,
+                ),
+            )
+        } else {
+            UpdateCheckResult.UpToDate(currentVersion)
+        }
+    }
+
+    private val DesktopPlatform.metadataName: String
+        get() = when (this) {
+            DesktopPlatform.MACOS -> "macos"
+            DesktopPlatform.WINDOWS -> "windows"
+            DesktopPlatform.LINUX -> "linux"
+            DesktopPlatform.UNKNOWN -> "unknown"
+        }
+}
 
 internal object ReleaseUpdateSelector {
     fun select(
@@ -88,6 +160,123 @@ internal object GitHubReleaseJsonParser {
             )
         }.toList()
         return GitHubRelease(version = version, releaseUrl = releaseUrl.jsonUnescape(), assets = assets)
+    }
+
+    private fun String.jsonUnescape(): String =
+        replace("\\/", "/")
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+}
+
+internal object ReleaseUpdateMetadataJsonParser {
+    fun parse(json: String): ReleaseUpdateMetadata? {
+        val schemaVersion = json.intField("schemaVersion") ?: return null
+        if (schemaVersion != 1) return null
+        val version = json.stringField("version") ?: return null
+        val tag = json.stringField("tag") ?: return null
+        val assetsJson = json.arrayField("assets") ?: return null
+        val assets = assetsJson.objectValues().mapNotNull { assetJson ->
+            val sha256 = assetJson.stringField("sha256")?.lowercase()
+            if (sha256 == null || !sha256.matches(Regex("[a-f0-9]{64}"))) return@mapNotNull null
+            ReleaseUpdateAsset(
+                platform = assetJson.stringField("platform") ?: return@mapNotNull null,
+                fileName = assetJson.stringField("fileName") ?: return@mapNotNull null,
+                url = assetJson.stringField("url") ?: return@mapNotNull null,
+                sha256 = sha256,
+                sizeBytes = assetJson.longField("size") ?: return@mapNotNull null,
+            )
+        }.toList()
+        if (assets.isEmpty()) return null
+        return ReleaseUpdateMetadata(version = version, tag = tag, assets = assets)
+    }
+
+    private fun String.stringField(name: String): String? {
+        val valueStart = valueStart(name) ?: return null
+        if (getOrNull(valueStart) != '"') return null
+        val start = valueStart + 1
+        var index = start
+        var escaped = false
+        while (index < length) {
+            val char = this[index]
+            if (char == '"' && !escaped) {
+                return substring(start, index).jsonUnescape()
+            }
+            escaped = char == '\\' && !escaped
+            if (char != '\\') escaped = false
+            index++
+        }
+        return null
+    }
+
+    private fun String.intField(name: String): Int? =
+        longField(name)?.toInt()
+
+    private fun String.longField(name: String): Long? {
+        val start = valueStart(name) ?: return null
+        var end = start
+        while (end < length && this[end].isDigit()) end++
+        return substring(start, end).toLongOrNull()
+    }
+
+    private fun String.arrayField(name: String): String? {
+        val valueStart = valueStart(name) ?: return null
+        if (getOrNull(valueStart) != '[') return null
+        var depth = 0
+        var inString = false
+        var escaped = false
+        for (index in valueStart until length) {
+            val char = this[index]
+            if (char == '"' && !escaped) inString = !inString
+            if (!inString) {
+                if (char == '[') depth++
+                if (char == ']') {
+                    depth--
+                    if (depth == 0) return substring(valueStart + 1, index)
+                }
+            }
+            escaped = char == '\\' && !escaped
+            if (char != '\\') escaped = false
+        }
+        return null
+    }
+
+    private fun String.objectValues(): List<String> {
+        val objects = mutableListOf<String>()
+        var start = -1
+        var depth = 0
+        var inString = false
+        var escaped = false
+        for (index in indices) {
+            val char = this[index]
+            if (char == '"' && !escaped) inString = !inString
+            if (!inString) {
+                if (char == '{') {
+                    if (depth == 0) start = index
+                    depth++
+                }
+                if (char == '}') {
+                    depth--
+                    if (depth == 0 && start >= 0) {
+                        objects += substring(start, index + 1)
+                        start = -1
+                    }
+                }
+            }
+            escaped = char == '\\' && !escaped
+            if (char != '\\') escaped = false
+        }
+        return objects
+    }
+
+    private fun String.valueStart(name: String): Int? {
+        val key = """"$name""""
+        val keyStart = indexOf(key)
+        if (keyStart < 0) return null
+        val colon = indexOf(':', startIndex = keyStart + key.length)
+        if (colon < 0) return null
+        var index = colon + 1
+        while (index < length && this[index].isWhitespace()) index++
+        return index.takeIf { it < length }
     }
 
     private fun String.jsonUnescape(): String =

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
@@ -5,6 +5,8 @@ data class UpdateCandidate(
     val releaseUrl: String,
     val assetName: String,
     val downloadUrl: String,
+    val sha256: String? = null,
+    val sizeBytes: Long? = null,
 )
 
 sealed interface UpdateCheckResult {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
@@ -1,17 +1,104 @@
 package io.github.cdsap.daemonitor.update
 
+import io.github.cdsap.daemonitor.Defaults
 import java.awt.Desktop
 import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.io.path.outputStream
 
 fun interface UpdateInstaller {
-    fun open(candidate: UpdateCandidate)
+    suspend fun open(candidate: UpdateCandidate, onProgress: (Double?) -> Unit)
 }
 
-class DesktopUpdateInstaller : UpdateInstaller {
-    override fun open(candidate: UpdateCandidate) {
-        require(Desktop.isDesktopSupported()) { "Desktop integration is not available" }
-        val desktop = Desktop.getDesktop()
-        require(desktop.isSupported(Desktop.Action.BROWSE)) { "Opening update downloads is not supported" }
-        desktop.browse(URI(candidate.downloadUrl))
+class DesktopUpdateInstaller(
+    private val updateDirectory: Path = Defaults.APP_SUPPORT_DIR.resolve("updates"),
+    private val opener: (Path) -> Unit = ::openWithDesktop,
+    private val downloader: suspend (UpdateCandidate, Path, (Double?) -> Unit) -> Path = ::downloadAndVerify,
+) : UpdateInstaller {
+    override suspend fun open(candidate: UpdateCandidate, onProgress: (Double?) -> Unit) {
+        val installer = downloader(candidate, updateDirectory, onProgress)
+        opener(installer)
     }
 }
+
+private fun openWithDesktop(path: Path) {
+    require(Desktop.isDesktopSupported()) { "Desktop integration is not available" }
+    val desktop = Desktop.getDesktop()
+    require(desktop.isSupported(Desktop.Action.OPEN)) { "Opening downloaded installers is not supported" }
+    desktop.open(path.toFile())
+}
+
+private suspend fun downloadAndVerify(
+    candidate: UpdateCandidate,
+    updateDirectory: Path,
+    onProgress: (Double?) -> Unit,
+): Path = withContext(Dispatchers.IO) {
+    val expectedSha256 = candidate.sha256
+        ?: error("Release checksum is unavailable; refusing to install ${candidate.assetName}")
+    require(expectedSha256.matches(Regex("[a-fA-F0-9]{64}"))) {
+        "Release checksum is invalid for ${candidate.assetName}"
+    }
+
+    Files.createDirectories(updateDirectory)
+    val tempPath = updateDirectory.resolve("${candidate.assetName}.download")
+    val finalPath = updateDirectory.resolve(candidate.assetName)
+    val client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()
+    val request = HttpRequest.newBuilder()
+        .uri(URI(candidate.downloadUrl))
+        .header("User-Agent", "Daemonitor")
+        .GET()
+        .build()
+    val response = client.send(request, HttpResponse.BodyHandlers.ofInputStream())
+    if (response.statusCode() !in 200..299) {
+        error("Download failed with HTTP ${response.statusCode()}")
+    }
+
+    val expectedBytes = candidate.sizeBytes
+        ?: response.headers().firstValueAsLong("Content-Length").orElse(-1).takeIf { it > 0 }
+    val digest = MessageDigest.getInstance("SHA-256")
+    var downloadedBytes = 0L
+    response.body().use { input ->
+        tempPath.outputStream().use { output ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = input.read(buffer)
+                if (read < 0) break
+                output.write(buffer, 0, read)
+                digest.update(buffer, 0, read)
+                downloadedBytes += read
+                onProgress(expectedBytes?.let { downloadedBytes.toDouble() / it.toDouble() })
+            }
+        }
+    }
+
+    if (expectedBytes != null && downloadedBytes != expectedBytes) {
+        Files.deleteIfExists(tempPath)
+        error("Downloaded ${downloadedBytes} bytes; expected ${expectedBytes}")
+    }
+    if (!UpdateDownloadVerifier.matches(digest.digest(), expectedSha256)) {
+        Files.deleteIfExists(tempPath)
+        error("Downloaded installer checksum did not match release metadata")
+    }
+    Files.move(
+        tempPath,
+        finalPath,
+        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+    )
+    onProgress(1.0)
+    finalPath
+}
+
+internal object UpdateDownloadVerifier {
+    fun matches(actualDigest: ByteArray, expectedSha256: String): Boolean =
+        actualDigest.toHex().equals(expectedSha256, ignoreCase = true)
+}
+
+private fun ByteArray.toHex(): String = joinToString(separator = "") { byte -> "%02x".format(byte) }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
@@ -91,7 +91,7 @@ class SettingsScreenUiTest {
     }
 
     @Test
-    fun `available update renders installer action`() = runComposeUiTest {
+    fun `available update renders download action`() = runComposeUiTest {
         var opened: UpdateCandidate? = null
         val candidate = UpdateCandidate(
             version = "1.0.3",
@@ -109,8 +109,28 @@ class SettingsScreenUiTest {
             }
         }
 
-        onNodeWithText("Open installer").performClick()
+        onNodeWithText("Download and open").performClick()
 
         assertEquals(candidate, opened)
+    }
+
+    @Test
+    fun `downloading update renders progress`() = runComposeUiTest {
+        val candidate = UpdateCandidate(
+            version = "1.0.3",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.3-macos.dmg",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+        )
+        setContent {
+            WatcherTheme {
+                SettingsScreen(
+                    SettingsUiState(updateState = UpdateUiState.Downloading(candidate, 0.42)),
+                    onRetentionDays = {},
+                )
+            }
+        }
+
+        onNodeWithText("Downloading Daemonitor-1.0.3-macos.dmg: 42%.").assertExists()
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -89,7 +89,8 @@ class SettingsViewModelTest {
     }
 
     @Test
-    fun `opening an available update delegates to installer`() {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `opening an available update delegates to installer`() = runTest {
         val opened = mutableListOf<UpdateCandidate>()
         val candidate = UpdateCandidate(
             version = "1.0.3",
@@ -98,16 +99,23 @@ class SettingsViewModelTest {
             downloadUrl = "https://example.com/Daemonitor-1.0.3-linux.deb",
         )
         val vm = SettingsViewModel(
-            updateInstaller = UpdateInstaller { opened += it },
+            updateInstaller = UpdateInstaller { update, progress ->
+                progress(0.5)
+                opened += update
+            },
+            scope = this,
         )
 
         vm.openUpdate(candidate)
+        advanceUntilIdle()
 
         assertEquals(listOf(candidate), opened)
+        assertEquals(UpdateUiState.ReadyToInstall(candidate), vm.state.value.updateState)
     }
 
     @Test
-    fun `installer failures are surfaced in update state`() {
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `installer failures are surfaced in update state`() = runTest {
         val candidate = UpdateCandidate(
             version = "1.0.3",
             releaseUrl = "https://example.com/release",
@@ -115,10 +123,12 @@ class SettingsViewModelTest {
             downloadUrl = "https://example.com/Daemonitor-1.0.3-windows.msi",
         )
         val vm = SettingsViewModel(
-            updateInstaller = UpdateInstaller { error("No desktop") },
+            updateInstaller = UpdateInstaller { _, _ -> error("No desktop") },
+            scope = this,
         )
 
         vm.openUpdate(candidate)
+        advanceUntilIdle()
 
         assertEquals(UpdateUiState.Failed("No desktop"), vm.state.value.updateState)
     }
@@ -128,7 +138,7 @@ class SettingsViewModelTest {
         scope: TestScope,
     ): SettingsViewModel = SettingsViewModel(
         updateChecker = { result },
-        updateInstaller = UpdateInstaller {},
+        updateInstaller = UpdateInstaller { _, _ -> },
         scope = scope,
     )
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopUpdateInstallerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopUpdateInstallerTest.kt
@@ -1,0 +1,56 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Files
+import java.nio.file.Path
+import java.security.MessageDigest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DesktopUpdateInstallerTest {
+
+    @Test
+    fun `downloads update and opens local installer path`(@TempDir tmp: Path) = runTest {
+        val opened = mutableListOf<Path>()
+        val progress = mutableListOf<Double?>()
+        val candidate = UpdateCandidate(
+            version = "1.0.4",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.4-macos.dmg",
+            downloadUrl = "https://example.com/Daemonitor-1.0.4-macos.dmg",
+            sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
+            sizeBytes = 128575584,
+        )
+        val installer = DesktopUpdateInstaller(
+            updateDirectory = tmp,
+            opener = { opened.add(it) },
+            downloader = { update, directory, onProgress ->
+                onProgress(0.5)
+                directory.resolve(update.assetName).also { path ->
+                    Files.writeString(path, "installer")
+                }
+            },
+        )
+
+        installer.open(candidate) { progress.add(it) }
+
+        assertEquals(listOf<Double?>(0.5), progress)
+        assertEquals(listOf(tmp.resolve("Daemonitor-1.0.4-macos.dmg")), opened)
+        assertTrue(Files.exists(opened.single()))
+    }
+
+    @Test
+    fun `matches expected installer checksum`() {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest("installer".toByteArray())
+
+        assertTrue(
+            UpdateDownloadVerifier.matches(
+                digest,
+                "9c0d294c05fc1d88d698034609bb81c0c69196327594e4c69d2915c80fd9850c",
+            ),
+        )
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateMetadataJsonParserTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateMetadataJsonParserTest.kt
@@ -1,0 +1,74 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class ReleaseUpdateMetadataJsonParserTest {
+
+    @Test
+    fun `parses update metadata assets with checksums`() {
+        val metadata = ReleaseUpdateMetadataJsonParser.parse(
+            """
+            {
+              "schemaVersion": 1,
+              "name": "Daemonitor",
+              "version": "1.0.4",
+              "tag": "v1.0.4",
+              "assets": [
+                {
+                  "platform": "macos",
+                  "fileName": "Daemonitor-1.0.4-macos.dmg",
+                  "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.4/Daemonitor-1.0.4-macos.dmg",
+                  "sha256": "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
+                  "size": 128575584
+                }
+              ]
+            }
+            """.trimIndent(),
+        )
+
+        requireNotNull(metadata)
+        assertEquals("1.0.4", metadata.version)
+        assertEquals("v1.0.4", metadata.tag)
+        assertEquals("Daemonitor-1.0.4-macos.dmg", metadata.assets.single().fileName)
+        assertEquals("24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1", metadata.assets.single().sha256)
+        assertEquals(128575584, metadata.assets.single().sizeBytes)
+    }
+
+    @Test
+    fun `rejects unsupported metadata schema`() {
+        assertNull(ReleaseUpdateMetadataJsonParser.parse("""{"schemaVersion": 99, "version": "1.0.4", "tag": "v1.0.4", "assets": []}"""))
+    }
+
+    @Test
+    fun `selects metadata asset for current platform`() {
+        val metadata = ReleaseUpdateMetadata(
+            version = "1.0.4",
+            tag = "v1.0.4",
+            assets = listOf(
+                ReleaseUpdateAsset(
+                    platform = "macos",
+                    fileName = "Daemonitor-1.0.4-macos.dmg",
+                    url = "https://example.com/Daemonitor-1.0.4-macos.dmg",
+                    sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
+                    sizeBytes = 128575584,
+                ),
+            ),
+        )
+
+        val result = ReleaseMetadataUpdateSelector.select(
+            metadata = metadata,
+            releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.4",
+            currentVersion = "1.0.3",
+            platform = DesktopPlatform.MACOS,
+        )
+
+        val available = assertIs<UpdateCheckResult.Available>(result)
+        assertEquals("1.0.4", available.candidate.version)
+        assertEquals("Daemonitor-1.0.4-macos.dmg", available.candidate.assetName)
+        assertEquals("24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1", available.candidate.sha256)
+        assertEquals(128575584, available.candidate.sizeBytes)
+    }
+}


### PR DESCRIPTION
## Summary
- use release metadata to select platform installers with checksum and size data
- download approved updates inside Daemonitor, verify SHA-256, then open the local installer
- show Settings progress/ready states and update docs for the in-app download flow

## Verification
- ./gradlew test --no-daemon --stacktrace
- ./gradlew createDistributable --no-daemon --stacktrace