### PR TITLE
Avoid global Main dispatcher in service tests

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -10,9 +10,11 @@ import io.github.cdsap.daemonitor.ui.settings.SettingsUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsViewModel
 import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -28,6 +30,7 @@ class WatcherService(
     private val updateChecker: suspend () -> UpdateCheckResult = {
         GitHubReleaseUpdateSource().check(BuildInfo.current.version)
     },
+    private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) {
     val liveViewModel = LiveViewModel()
     val historyViewModel = HistoryViewModel()
@@ -41,6 +44,7 @@ class WatcherService(
         onRetentionChange = ::onRetentionChanged,
         onAppearanceChange = ::onAppearanceChanged,
         updateChecker = updateChecker,
+        scope = CoroutineScope(SupervisorJob() + uiDispatcher),
     )
 
     private var serviceScope: CoroutineScope? = null
@@ -90,7 +94,7 @@ class WatcherService(
     private suspend fun refreshHistory() {
         val builds = database.recentBuilds()
         val projects = database.distinctProjects()
-        withContext(Dispatchers.Main) {
+        withContext(uiDispatcher) {
             historyViewModel.onBuilds(builds)
             historyViewModel.onProjects(projects)
         }
@@ -102,7 +106,7 @@ class WatcherService(
 
         // Surface the selected daemon's tail, if any is selected.
         val selectedTail = selectedDaemonTail(result)
-        withContext(Dispatchers.Main) {
+        withContext(uiDispatcher) {
             liveViewModel.onPoll(result.processes, selectedTail)
         }
 
@@ -118,7 +122,7 @@ class WatcherService(
             throw error
         } catch (error: Exception) {
             val errorType = error::class.simpleName ?: "UnknownError"
-            withContext(Dispatchers.Main) {
+            withContext(uiDispatcher) {
                 liveViewModel.onPollFailure(clock(), errorType)
             }
         }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -4,13 +4,11 @@ import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.ui.settings.UpdateUiState
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.Test
@@ -23,9 +21,9 @@ class WatcherServiceTest {
     @Test
     fun `failed poll records sanitized error and failure timestamp`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
         try {
-            val service = service(database, tmp, clock = { 100 }) {
+            val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { 100 }) {
                 error("secret command line and log content")
             }
 
@@ -36,7 +34,6 @@ class WatcherServiceTest {
             assertEquals("IllegalStateException", error?.errorType)
             assertFalse(error.toString().contains("secret"))
         } finally {
-            Dispatchers.resetMain()
             database.close()
         }
     }
@@ -44,11 +41,11 @@ class WatcherServiceTest {
     @Test
     fun `repeated failure replaces the latest failure timestamp`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
         try {
             var now = 100L
             var firstFailure = true
-            val service = service(database, tmp, clock = { now }) {
+            val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { now }) {
                 if (firstFailure) throw IllegalArgumentException("first failure")
                 error("second failure")
             }
@@ -62,7 +59,6 @@ class WatcherServiceTest {
             assertEquals(200, error?.failedAtMs)
             assertEquals("IllegalStateException", error?.errorType)
         } finally {
-            Dispatchers.resetMain()
             database.close()
         }
     }
@@ -70,10 +66,10 @@ class WatcherServiceTest {
     @Test
     fun `successful retry clears the previous failure`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
         try {
             var fail = true
-            val service = service(database, tmp) {
+            val service = service(database, tmp, uiDispatcher = uiDispatcher) {
                 if (fail) error("failure")
                 WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
             }
@@ -84,7 +80,6 @@ class WatcherServiceTest {
 
             assertNull(service.liveViewModel.state.value.pollError)
         } finally {
-            Dispatchers.resetMain()
             database.close()
         }
     }
@@ -92,12 +87,13 @@ class WatcherServiceTest {
     @Test
     fun `starting service checks for updates`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        Dispatchers.setMain(UnconfinedTestDispatcher(testScheduler))
+        val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
         try {
             var updateChecks = 0
             val service = service(
                 database = database,
                 tmp = tmp,
+                uiDispatcher = uiDispatcher,
                 updateChecker = {
                     updateChecks += 1
                     UpdateCheckResult.UpToDate("1.0.3")
@@ -112,7 +108,6 @@ class WatcherServiceTest {
             assertEquals(1, updateChecks)
             assertEquals(UpdateUiState.UpToDate("1.0.3"), service.settingsViewModel.state.value.updateState)
         } finally {
-            Dispatchers.resetMain()
             database.close()
         }
     }
@@ -120,6 +115,7 @@ class WatcherServiceTest {
     private fun service(
         database: WatcherDatabase,
         tmp: Path,
+        uiDispatcher: CoroutineDispatcher,
         clock: () -> Long = { 0 },
         updateChecker: suspend () -> UpdateCheckResult = { UpdateCheckResult.UpToDate("1.0.3") },
         pollAction: suspend () -> WatcherRuntime.PollResult,
@@ -130,5 +126,6 @@ class WatcherServiceTest {
         clock = clock,
         pollAction = pollAction,
         updateChecker = updateChecker,
+        uiDispatcher = uiDispatcher,
     )
 }


### PR DESCRIPTION
## Summary
- inject the UI dispatcher into WatcherService instead of hardcoding Dispatchers.Main in update paths
- pass a test dispatcher directly from WatcherServiceTest
- remove process-wide Dispatchers.setMain/resetMain usage that races on Linux CI

## Fixes
- Ubuntu CI failure in run 30942094090 / job 92102823278: Dispatchers.Main is used concurrently with setting it

## Verification
- ./gradlew test --no-daemon --stacktrace --tests io.github.cdsap.daemonitor.WatcherServiceTest
- ./gradlew test --no-daemon --stacktrace