### PR TITLE
fix: add a icon representing the status of mcp close to the headless ico

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -100,6 +100,7 @@ internal fun DaemonitorContent(
             AppScaffold(
                 onSwitchToHeadless = onSwitchToHeadless,
                 settingsNotificationCount = settingsState.updateNotificationCount,
+                mcpState = settingsState.mcpState,
                 liveContent = {
                     LiveMonitorScreen(
                         state = liveState,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt
@@ -3,6 +3,7 @@ package io.github.cdsap.daemonitor.ui.common
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -13,8 +14,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.History
+import androidx.compose.material.icons.filled.Hub
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Speed
@@ -40,6 +43,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.BuildInfo
+import io.github.cdsap.daemonitor.ui.settings.McpUiState
 
 /** Top-level navigation: Live Monitor and Historical tabs (U7). Resolves the navigation-model gap. */
 @Composable
@@ -50,6 +54,7 @@ fun AppScaffold(
     settingsContent: @Composable () -> Unit,
     onSwitchToHeadless: () -> Unit = {},
     settingsNotificationCount: Int = 0,
+    mcpState: McpUiState = McpUiState.Stopped,
     buildInfo: BuildInfo = BuildInfo.current,
 ) {
     var selectedTab by remember { mutableStateOf(0) }
@@ -60,6 +65,7 @@ fun AppScaffold(
             onSelectTab = { selectedTab = it },
             onSwitchToHeadless = onSwitchToHeadless,
             settingsNotificationCount = settingsNotificationCount,
+            mcpState = mcpState,
         )
         HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
         Column(modifier = Modifier.weight(1f)) {
@@ -82,6 +88,7 @@ private fun AppHeader(
     onSelectTab: (Int) -> Unit,
     onSwitchToHeadless: () -> Unit,
     settingsNotificationCount: Int,
+    mcpState: McpUiState,
 ) {
     BoxWithConstraints(
         modifier = Modifier
@@ -124,6 +131,7 @@ private fun AppHeader(
                 }
             }
             Spacer(modifier = Modifier.weight(1f))
+            McpStatusIcon(mcpState)
             IconButton(
                 onClick = onSwitchToHeadless,
                 modifier = Modifier.size(40.dp),
@@ -138,8 +146,8 @@ private fun AppHeader(
             if (!compact) {
                 Spacer(modifier = Modifier.width(Space.xs))
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
-                    androidx.compose.foundation.layout.Box(
-                        modifier = Modifier.size(7.dp).background(LocalAccentColors.current.success, androidx.compose.foundation.shape.CircleShape),
+                    Box(
+                        modifier = Modifier.size(7.dp).background(LocalAccentColors.current.success, CircleShape),
                     )
                     Text("LOCAL", style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
                 }
@@ -151,6 +159,30 @@ private fun AppHeader(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun McpStatusIcon(mcpState: McpUiState) {
+    val accents = LocalAccentColors.current
+    val (contentDescription, tint, background) = when (mcpState) {
+        McpUiState.Stopped -> Triple("MCP stopped", accents.neutral, accents.neutralBg)
+        McpUiState.Starting -> Triple("MCP starting", accents.warn, accents.warnBg)
+        is McpUiState.Running -> Triple("MCP running", accents.success, accents.successBg)
+        is McpUiState.Failed -> Triple("MCP failed", accents.danger, accents.dangerBg)
+    }
+    Box(
+        modifier = Modifier
+            .size(32.dp)
+            .background(background, CircleShape),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            Icons.Filled.Hub,
+            contentDescription = contentDescription,
+            tint = tint,
+            modifier = Modifier.size(18.dp),
+        )
     }
 }
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffoldUiTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.BuildInfo
+import io.github.cdsap.daemonitor.ui.settings.McpUiState
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -99,5 +100,42 @@ class AppScaffoldUiTest {
         onNodeWithContentDescription("Switch to headless mode").performClick()
 
         assertTrue(switchedToHeadless)
+    }
+
+    @Test
+    fun `header shows mcp stopped status by default`() = runComposeUiTest {
+        setContent {
+            WatcherTheme {
+                AppScaffold(
+                    liveContent = { Text("Live") },
+                    historyContent = { Text("History") },
+                    settingsContent = { Text("Settings") },
+                )
+            }
+        }
+
+        onNodeWithContentDescription("MCP stopped").assertExists()
+    }
+
+    @Test
+    fun `header shows active mcp statuses`() = runComposeUiTest {
+        listOf(
+            McpUiState.Starting to "MCP starting",
+            McpUiState.Running("http://127.0.0.1:17333/mcp") to "MCP running",
+            McpUiState.Failed("Port already in use") to "MCP failed",
+        ).forEach { (state, contentDescription) ->
+            setContent {
+                WatcherTheme {
+                    AppScaffold(
+                        mcpState = state,
+                        liveContent = { Text("Live") },
+                        historyContent = { Text("History") },
+                        settingsContent = { Text("Settings") },
+                    )
+                }
+            }
+
+            onNodeWithContentDescription(contentDescription).assertExists()
+        }
     }
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#69: Add a icon representing the status of mcp close to the headless icon / version app

Fixes #69

## Agent routing

- Selected agent: `cursor`
- Routing reason: `sufficient_codex_capacity`
- Complexity: `unknown`

## Verification

- `./gradlew test`