### PR TITLE
fix: add cross-platform in-app self-update and restart to update flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,17 +41,26 @@ jobs:
             platform: linux
             package_task: packageDeb
             package_glob: build/compose/binaries/main/deb/*.deb
+            package_ext: deb
+            update_ext: tar.gz
             launcher: build/compose/binaries/main/app/Daemonitor/bin/Daemonitor
+            app_path: build/compose/binaries/main/app/Daemonitor
           - os: windows-latest
             platform: windows
             package_task: packageMsi
             package_glob: build/compose/binaries/main/msi/*.msi
+            package_ext: msi
+            update_ext: zip
             launcher: build/compose/binaries/main/app/Daemonitor/Daemonitor.exe
+            app_path: build/compose/binaries/main/app/Daemonitor
           - os: macos-latest
             platform: macos
             package_task: packageDmg
             package_glob: build/compose/binaries/main/dmg/*.dmg
+            package_ext: dmg
+            update_ext: zip
             launcher: build/compose/binaries/main/app/Daemonitor.app/Contents/MacOS/Daemonitor
+            app_path: build/compose/binaries/main/app/Daemonitor.app
     runs-on: ${{ matrix.os }}
     defaults:
       run:
@@ -89,9 +98,24 @@ jobs:
         id: package-version
         run: echo "value=$(./gradlew -q printNativePackageVersion --no-daemon)" >> "$GITHUB_OUTPUT"
 
-      - name: Stage release asset
+      - name: Detect CPU architecture
+        id: arch
+        run: |
+          machine=$(uname -m | tr '[:upper:]' '[:lower:]')
+          case "$machine" in
+            arm64|aarch64) arch=arm64 ;;
+            x86_64|amd64) arch=x64 ;;
+            *)
+              echo "Unsupported architecture: $machine" >&2
+              exit 1
+              ;;
+          esac
+          echo "value=$arch" >> "$GITHUB_OUTPUT"
+
+      - name: Stage release assets
         id: asset
         run: |
+          set -euo pipefail
           shopt -s nullglob
           packages=(${{ matrix.package_glob }})
           if (( ${#packages[@]} != 1 )); then
@@ -99,21 +123,53 @@ jobs:
             exit 1
           fi
           test -s "${packages[0]}"
-          extension="${packages[0]##*.}"
-          asset="Daemonitor-${{ steps.package-version.outputs.value }}-${{ matrix.platform }}.${extension}"
-          mkdir -p release-assets
-          cp "${packages[0]}" "release-assets/${asset}"
-          echo "path=release-assets/${asset}" >> "$GITHUB_OUTPUT"
-          echo "name=${asset}" >> "$GITHUB_OUTPUT"
-          echo "### Release asset" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Platform: ${{ matrix.platform }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "- Asset: ${asset}" >> "$GITHUB_STEP_SUMMARY"
+          test -e "${{ matrix.app_path }}"
 
-      - name: Upload staged release asset
+          version="${{ steps.package-version.outputs.value }}"
+          platform="${{ matrix.platform }}"
+          arch="${{ steps.arch.outputs.value }}"
+          mkdir -p release-assets
+
+          installer="Daemonitor-${version}-${platform}-${arch}.${{ matrix.package_ext }}"
+          cp "${packages[0]}" "release-assets/${installer}"
+
+          update_asset="Daemonitor-${version}-${platform}-${arch}.${{ matrix.update_ext }}"
+          app_dir="$(dirname "${{ matrix.app_path }}")"
+          app_name="$(basename "${{ matrix.app_path }}")"
+          update_path="$GITHUB_WORKSPACE/release-assets/${update_asset}"
+          case "${{ matrix.update_ext }}" in
+            zip)
+              if command -v zip >/dev/null 2>&1; then
+                (cd "$app_dir" && zip -qry "$update_path" "$app_name")
+              else
+                powershell.exe -NoProfile -Command \
+                  "Compress-Archive -Path (Join-Path '$app_dir' '$app_name') -DestinationPath '$update_path' -Force"
+              fi
+              ;;
+            tar.gz)
+              (cd "$app_dir" && tar -czf "$update_path" "$app_name")
+              ;;
+            *)
+              echo "Unsupported update extension: ${{ matrix.update_ext }}" >&2
+              exit 1
+              ;;
+          esac
+          test -s "release-assets/${update_asset}"
+
+          {
+            echo "installer=${installer}"
+            echo "update=${update_asset}"
+          } >> "$GITHUB_OUTPUT"
+          echo "### Release assets" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Platform: ${platform}/${arch}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Installer: ${installer}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Update package: ${update_asset}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload staged release assets
         uses: actions/upload-artifact@v4
         with:
-          name: release-asset-${{ matrix.platform }}
-          path: ${{ steps.asset.outputs.path }}
+          name: release-asset-${{ matrix.platform }}-${{ steps.arch.outputs.value }}
+          path: release-assets/*
           if-no-files-found: error
           retention-days: 7
 
@@ -159,6 +215,7 @@ jobs:
           echo "- latest.json" >> "$GITHUB_STEP_SUMMARY"
           echo "- update.json" >> "$GITHUB_STEP_SUMMARY"
           echo "- checksums.txt" >> "$GITHUB_STEP_SUMMARY"
+          echo "- per-asset .sha256 sidecars" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload assets and metadata to GitHub release
         env:

--- a/README.md
+++ b/README.md
@@ -104,26 +104,31 @@ owned by the current user.
 
 Daemonitor is distributed as a native desktop app per operating system:
 
-| OS | Package |
-|----|---------|
-| macOS | `.dmg` |
-| Windows | `.msi` |
-| Linux | `.deb` |
+| OS | First-time installer | In-app update package |
+|----|----------------------|------------------------|
+| macOS | `.dmg` | `.zip` app bundle |
+| Windows | `.msi` | `.zip` app directory |
+| Linux | `.deb` | `.tar.gz` standalone image |
+
+Release asset names include the CPU architecture (`x64` or `arm64`), for example
+`Daemonitor-1.0.7-macos-arm64.dmg` and `Daemonitor-1.0.7-macos-arm64.zip`.
 
 The installed app does not require a project-local Gradle setup. It only reads local process
 metadata and Gradle daemon logs for the current user.
 
-Linux distribution starts with the GitHub Releases `.deb`. The follow-up update strategy is a signed
-apt repository with advisory in-app prompts only; see
+Linux distribution starts with the GitHub Releases `.deb` for package installs and a `.tar.gz`
+update package for writable standalone installs. Package-managed Linux prompts stay advisory; see
 [Linux Update Distribution](docs/linux-update-distribution.md).
 
 ## Updates
 
 Daemonitor checks GitHub Releases once at startup and marks the Settings tab as `Settings (1)` when
 a newer version is available. The Settings tab can also check manually. When a newer release is
-available, Daemonitor downloads the matching installer for the current operating system only after
-you approve it, verifies the SHA-256 checksum from release metadata, and opens the local installer.
-The app does not silently install updates.
+available, Daemonitor selects the matching artifact for the current operating system and CPU
+architecture only after you approve the download, verifies the SHA-256 checksum from release
+metadata, and either stages an update package for **Restart and Update** or opens the platform
+installer when automatic installation is not supported for the current install. The app does not
+silently install updates while it is running.
 
 ## Run from source
 

--- a/docs/linux-update-distribution.md
+++ b/docs/linux-update-distribution.md
@@ -2,30 +2,34 @@
 
 ## Decision
 
-Daemonitor will keep the initial Linux release path as a direct `.deb` asset on GitHub Releases.
-After that Phase 1 flow is working, Linux updates should move to a signed apt repository as the
-preferred distribution channel.
+Daemonitor will keep the initial Linux release path as a direct `.deb` asset on GitHub Releases,
+plus a `.tar.gz` update package for standalone installations that can safely self-update. After
+that flow is working, Linux package updates should move to a signed apt repository as the preferred
+distribution channel for package-managed installs.
 
-The app must not try to self-install updates on Linux. Linux update prompts should describe the
-available version and send the user to the appropriate system-managed install path:
+The app must not try to self-install updates on Linux installations owned by the system package
+manager. Package-managed Linux update prompts should describe the available version and send the
+user to the appropriate system-managed install path:
 
 - If the current install came from the apt repository, prompt the user to update through their
   package manager.
 - If the current install came from a downloaded `.deb`, prompt the user to download and open the
   newer GitHub Releases `.deb`.
-- If the install source is unknown, offer both paths and explain that apt is preferred once the
-  repository is configured.
+- If the current install is a writable standalone / archive layout, Daemonitor may download the
+  matching `.tar.gz` update package, stage it, and apply it after **Restart and Update**.
+- If the install source is unknown, offer the manual package path and explain that apt is preferred
+  once the repository is configured.
 
-This keeps Phase 1 independent from repository setup and avoids silent privilege escalation from
-inside the desktop app.
+This keeps package-manager installs independent from repository setup and avoids silent privilege
+escalation or unsafe replacement of files owned by `dpkg`/`rpm` from inside the desktop app.
 
 ## Direct `.deb` Download
 
 Direct `.deb` downloads are the smallest viable Linux distribution path:
 
-- GitHub Releases already publishes `Daemonitor-<version>-linux.deb`.
+- GitHub Releases already publishes `Daemonitor-<version>-linux-<arch>.deb`.
 - Users can download and open the package with their desktop software installer, or install it with
-  a terminal command such as `sudo apt install ./Daemonitor-<version>-linux.deb`.
+  a terminal command such as `sudo apt install ./Daemonitor-<version>-linux-<arch>.deb`.
 - The release asset can be produced by the current `packageDeb` CI path without repository metadata.
 
 The tradeoff is that direct `.deb` installs do not provide a standard update feed. The app can detect
@@ -46,13 +50,15 @@ preferred path once repository hosting, package metadata, and signing are in pla
 
 ## Update Prompt Behavior
 
-Linux prompts must be advisory, not self-installing:
+Linux package-managed prompts must be advisory, not self-installing:
 
 - Show the available version and release link.
 - Never run `sudo`, `pkexec`, `apt`, `dpkg`, or any privileged installer command from the app.
 - For apt installs, say to update from the system package manager and link to repository setup docs.
 - For direct `.deb` installs, the app may download and verify the GitHub Releases `.deb`, then open
   it with the OS package installer so the operating system owns privilege prompts.
+- For writable standalone installs, the app may stage the `.tar.gz` update package and apply it only
+  after the user chooses **Restart and Update**.
 - Allow dismissing or deferring the prompt so background collection is not blocked.
 
 ## Package Metadata Requirements

--- a/docs/update-metadata.md
+++ b/docs/update-metadata.md
@@ -1,9 +1,9 @@
 # Update Metadata Contract
 
 Daemonitor publishes update metadata to each tag-triggered GitHub Release so updater clients can
-validate release information and native downloads before presenting or opening installers. The
-desktop app uses this metadata to download the selected installer in-app, verify it, and then hand
-off to the operating system installer.
+validate release information and native downloads before staging or opening installers. The desktop
+app uses this metadata to download the selected artifact in-app, verify it, and either stage an
+automatic **Restart and Update** package or hand off to the operating system installer.
 
 ## Release assets
 
@@ -12,34 +12,55 @@ Each release includes these machine-readable files:
 - `latest.json`: canonical metadata for the current release.
 - `update.json`: an alias with the same content for updater clients that prefer an update-specific
   file name.
-- `checksums.txt`: SHA-256 checksums for every native installer, in the common
+- `checksums.txt`: SHA-256 checksums for every native installer and update package, in the common
   `<sha256>  <fileName>` format.
+- `<asset>.sha256`: per-asset SHA-256 sidecars for the in-app updater and manual verification.
 
-The release also includes one native installer per supported platform:
+The release also includes platform/architecture native installers and update packages:
 
-- `Daemonitor-<version>-linux.deb`
-- `Daemonitor-<version>-windows.msi`
-- `Daemonitor-<version>-macos.dmg`
+### Installers (first-time / manual)
+
+- `Daemonitor-<version>-linux-<arch>.deb`
+- `Daemonitor-<version>-windows-<arch>.msi`
+- `Daemonitor-<version>-macos-<arch>.dmg`
+
+### Update packages (in-app Restart and Update)
+
+- `Daemonitor-<version>-linux-<arch>.tar.gz`
+- `Daemonitor-<version>-windows-<arch>.zip`
+- `Daemonitor-<version>-macos-<arch>.zip`
 
 `<version>` is read from the Gradle `printNativePackageVersion` task during the tag-triggered
-release workflow. The same value is used for installer names and metadata.
+release workflow. `<arch>` is `x64` or `arm64` for the runner that built the asset. The same values
+are used for installer names, update package names, and metadata.
 
 ## JSON schema
 
-`latest.json` and `update.json` currently use `schemaVersion` `1`:
+`latest.json` and `update.json` currently use `schemaVersion` `2`:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "name": "Daemonitor",
-  "version": "1.0.2",
-  "tag": "v1.0.2",
+  "version": "1.0.7",
+  "tag": "v1.0.7",
   "repository": "https://github.com/cdsap/daemonitor",
   "assets": [
     {
-      "platform": "linux",
-      "fileName": "Daemonitor-1.0.2-linux.deb",
-      "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.2/Daemonitor-1.0.2-linux.deb",
+      "platform": "macos",
+      "arch": "arm64",
+      "role": "update",
+      "fileName": "Daemonitor-1.0.7-macos-arm64.zip",
+      "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-arm64.zip",
+      "sha256": "<64 lowercase hex characters>",
+      "size": 123456
+    },
+    {
+      "platform": "macos",
+      "arch": "arm64",
+      "role": "installer",
+      "fileName": "Daemonitor-1.0.7-macos-arm64.dmg",
+      "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-arm64.dmg",
       "sha256": "<64 lowercase hex characters>",
       "size": 123456
     }
@@ -48,18 +69,30 @@ release workflow. The same value is used for installer names and metadata.
 ```
 
 Clients should treat `schemaVersion`, `version`, `tag`, and `assets` as required. Each asset entry
-must include `platform`, `fileName`, `url`, `sha256`, and `size`.
+must include `platform`, `fileName`, `url`, `sha256`, and `size`. Schema `2` also includes `arch`
+(`x64` / `arm64`) and `role` (`update` / `installer`).
+
+Schema `1` metadata without `arch`/`role` remains readable: clients infer role from the file
+extension and treat missing architecture as a legacy fallback for the current OS.
 
 ## Client validation
 
 Updater clients should:
 
 1. Download `latest.json` or `update.json` from the GitHub Release.
-2. Confirm `schemaVersion` is supported.
-3. Select the asset matching the current platform.
-4. Download the asset from `url`.
-5. Compute SHA-256 over the downloaded bytes and compare it with `sha256`.
-6. Open the verified local installer only after the user approves the update.
+2. Confirm `schemaVersion` is supported (`1` or `2`).
+3. Detect the current operating system and CPU architecture.
+4. Select the asset matching the current platform and architecture.
+5. Prefer `role=update` packages when the installation supports automatic Restart and Update.
+6. Prefer `role=installer` assets when automatic installation is unavailable.
+7. Download the asset from `url` only from the official `cdsap/daemonitor` GitHub repository.
+8. Compute SHA-256 over the downloaded bytes and compare it with `sha256`.
+9. Stage validated update packages without terminating Daemonitor, or open verified installers only
+   after the user approves the update.
+10. Apply staged updates only after the user chooses **Restart and Update**.
 
-Clients may also download `checksums.txt` and compare it against the JSON asset list as a secondary
-integrity check.
+Clients may also download `checksums.txt` or `<asset>.sha256` and compare them against the JSON
+asset list as a secondary integrity check.
+
+A release is not eligible for automatic updates on a given machine when the required
+platform/architecture update package is missing.

--- a/scripts/generate-release-metadata.sh
+++ b/scripts/generate-release-metadata.sh
@@ -31,57 +31,112 @@ file_size() {
   wc -c < "$1" | tr -d '[:space:]'
 }
 
-asset_for() {
-  local platform=$1
-  local extension=$2
-  local asset="$assets_dir/Daemonitor-${version}-${platform}.${extension}"
-  if [[ ! -s "$asset" ]]; then
-    echo "Missing non-empty release asset: $asset" >&2
-    exit 1
+infer_platform() {
+  local name=$1
+  if [[ "$name" == *"-macos-"* || "$name" == *"-macos."* ]]; then
+    printf 'macos\n'
+  elif [[ "$name" == *"-windows-"* || "$name" == *"-windows."* ]]; then
+    printf 'windows\n'
+  elif [[ "$name" == *"-linux-"* || "$name" == *"-linux."* ]]; then
+    printf 'linux\n'
+  else
+    return 1
   fi
-  printf '%s\n' "$asset"
+}
+
+infer_arch() {
+  local name=$1
+  if [[ "$name" == *"-arm64."* || "$name" == *"-arm64-"* || "$name" == *".arm64."* ]]; then
+    printf 'arm64\n'
+  elif [[ "$name" == *"-x64."* || "$name" == *"-x64-"* || "$name" == *"-amd64."* || "$name" == *"-x86_64."* ]]; then
+    printf 'x64\n'
+  else
+    printf 'unknown\n'
+  fi
+}
+
+infer_role() {
+  local name=$1
+  case "$name" in
+    *.zip|*.tar.gz|*.tgz) printf 'update\n' ;;
+    *) printf 'installer\n' ;;
+  esac
 }
 
 mkdir -p "$output_dir"
 
-platforms=(linux windows macos)
-extensions=(deb msi dmg)
-assets=()
-checksums=()
-sizes=()
-
-for index in "${!platforms[@]}"; do
-  asset=$(asset_for "${platforms[$index]}" "${extensions[$index]}")
-  assets+=("$asset")
-  checksums+=("$(sha256_file "$asset")")
-  sizes+=("$(file_size "$asset")")
+shopt -s nullglob
+asset_files=()
+for path in "$assets_dir"/*; do
+  name=$(basename "$path")
+  case "$name" in
+    *.sha256|latest.json|update.json|checksums.txt) continue ;;
+  esac
+  if [[ -f "$path" && -s "$path" ]]; then
+    asset_files+=("$path")
+  fi
 done
 
-{
-  for index in "${!assets[@]}"; do
-    printf '%s  %s\n' "${checksums[$index]}" "$(basename "${assets[$index]}")"
-  done
-} > "$output_dir/checksums.txt"
+if (( ${#asset_files[@]} == 0 )); then
+  echo "No release assets found in $assets_dir" >&2
+  exit 1
+fi
+
+IFS=$'\n' asset_files=($(printf '%s\n' "${asset_files[@]}" | LC_ALL=C sort))
+unset IFS
+
+checksums_file="$output_dir/checksums.txt"
+: > "$checksums_file"
+
+declare -a platforms
+declare -a arches
+declare -a roles
+declare -a names
+declare -a checksums
+declare -a sizes
+
+for asset in "${asset_files[@]}"; do
+  name=$(basename "$asset")
+  platform=$(infer_platform "$name") || {
+    echo "Unable to infer platform for asset: $name" >&2
+    exit 1
+  }
+  arch=$(infer_arch "$name")
+  role=$(infer_role "$name")
+  checksum=$(sha256_file "$asset")
+  size=$(file_size "$asset")
+
+  platforms+=("$platform")
+  arches+=("$arch")
+  roles+=("$role")
+  names+=("$name")
+  checksums+=("$checksum")
+  sizes+=("$size")
+
+  printf '%s  %s\n' "$checksum" "$name" >> "$checksums_file"
+  printf '%s\n' "$checksum" > "$assets_dir/${name}.sha256"
+done
 
 metadata_file="$output_dir/latest.json"
 {
   printf '{\n'
-  printf '  "schemaVersion": 1,\n'
+  printf '  "schemaVersion": 2,\n'
   printf '  "name": "Daemonitor",\n'
   printf '  "version": "%s",\n' "$version"
   printf '  "tag": "%s",\n' "$tag"
   printf '  "repository": "https://github.com/%s",\n' "$repository"
   printf '  "assets": [\n'
-  for index in "${!assets[@]}"; do
-    asset_name=$(basename "${assets[$index]}")
+  for index in "${!names[@]}"; do
     comma=","
-    if [[ "$index" == "$((${#assets[@]} - 1))" ]]; then
+    if [[ "$index" == "$((${#names[@]} - 1))" ]]; then
       comma=""
     fi
     printf '    {\n'
     printf '      "platform": "%s",\n' "${platforms[$index]}"
-    printf '      "fileName": "%s",\n' "$asset_name"
-    printf '      "url": "https://github.com/%s/releases/download/%s/%s",\n' "$repository" "$tag" "$asset_name"
+    printf '      "arch": "%s",\n' "${arches[$index]}"
+    printf '      "role": "%s",\n' "${roles[$index]}"
+    printf '      "fileName": "%s",\n' "${names[$index]}"
+    printf '      "url": "https://github.com/%s/releases/download/%s/%s",\n' "$repository" "$tag" "${names[$index]}"
     printf '      "sha256": "%s",\n' "${checksums[$index]}"
     printf '      "size": %s\n' "${sizes[$index]}"
     printf '    }%s\n' "$comma"

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -127,6 +127,8 @@ internal fun DaemonitorContent(
                         onMcpEnabled = service.settingsViewModel::setMcpEnabled,
                         onCheckForUpdates = service.settingsViewModel::checkForUpdates,
                         onOpenUpdate = service.settingsViewModel::openUpdate,
+                        onRestartAndUpdate = service.settingsViewModel::restartAndUpdate,
+                        onOpenManualDownload = service.settingsViewModel::openManualDownload,
                     )
                 },
             )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -51,6 +51,8 @@ fun SettingsScreen(
     onMcpEnabled: (Boolean) -> Unit = {},
     onCheckForUpdates: () -> Unit = {},
     onOpenUpdate: (io.github.cdsap.daemonitor.update.UpdateCandidate) -> Unit = {},
+    onRestartAndUpdate: () -> Unit = {},
+    onOpenManualDownload: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -94,7 +96,7 @@ fun SettingsScreen(
         Spacer(Modifier.height(Space.md))
         SectionCard(
             "Updates",
-            modifier = Modifier.fillMaxWidth().height(180.dp).padding(horizontal = Space.lg),
+            modifier = Modifier.fillMaxWidth().height(210.dp).padding(horizontal = Space.lg),
         ) {
             Column {
                 Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(Space.xs)) {
@@ -119,26 +121,61 @@ fun SettingsScreen(
                 Row(horizontalArrangement = Arrangement.spacedBy(Space.sm), verticalAlignment = Alignment.CenterVertically) {
                     OutlinedButton(
                         onClick = onCheckForUpdates,
-                        enabled = state.updateState != UpdateUiState.Checking,
+                        enabled = state.updateState != UpdateUiState.Checking &&
+                            state.updateState !is UpdateUiState.Downloading,
                         shape = RoundedCornerShape(Radius.sm),
                     ) {
                         Icon(Icons.Filled.Refresh, contentDescription = null)
                         Spacer(Modifier.width(Space.xs))
                         Text(if (state.updateState == UpdateUiState.Checking) "Checking" else "Check for updates")
                     }
-                    val available = state.updateState as? UpdateUiState.Available
-                    val ready = state.updateState as? UpdateUiState.ReadyToInstall
-                    val candidate = available?.candidate ?: ready?.candidate
-                    if (candidate != null) {
-                        Button(
-                            onClick = { onOpenUpdate(candidate) },
-                            enabled = state.updateState !is UpdateUiState.Downloading,
-                            shape = RoundedCornerShape(Radius.sm),
-                        ) {
-                            Icon(Icons.Filled.Download, contentDescription = null)
-                            Spacer(Modifier.width(Space.xs))
-                            Text(if (ready != null) "Open again" else "Download and open")
+                    when (val updateState = state.updateState) {
+                        is UpdateUiState.Available -> {
+                            Button(
+                                onClick = { onOpenUpdate(updateState.candidate) },
+                                shape = RoundedCornerShape(Radius.sm),
+                            ) {
+                                Icon(Icons.Filled.Download, contentDescription = null)
+                                Spacer(Modifier.width(Space.xs))
+                                Text("Download Update")
+                            }
                         }
+                        is UpdateUiState.ReadyToInstall -> {
+                            if (updateState.candidate.installMode == io.github.cdsap.daemonitor.update.UpdateInstallMode.Automatic &&
+                                updateState.staged != null
+                            ) {
+                                Button(
+                                    onClick = onRestartAndUpdate,
+                                    shape = RoundedCornerShape(Radius.sm),
+                                ) {
+                                    Icon(Icons.Filled.Refresh, contentDescription = null)
+                                    Spacer(Modifier.width(Space.xs))
+                                    Text("Restart and Update")
+                                }
+                            } else {
+                                Button(
+                                    onClick = { onOpenUpdate(updateState.candidate) },
+                                    shape = RoundedCornerShape(Radius.sm),
+                                ) {
+                                    Icon(Icons.Filled.Download, contentDescription = null)
+                                    Spacer(Modifier.width(Space.xs))
+                                    Text("Open again")
+                                }
+                            }
+                        }
+                        is UpdateUiState.Failed -> {
+                            if (updateState.releaseUrl != null) {
+                                OutlinedButton(
+                                    onClick = onOpenManualDownload,
+                                    shape = RoundedCornerShape(Radius.sm),
+                                ) {
+                                    Icon(Icons.Filled.Download, contentDescription = null)
+                                    Spacer(Modifier.width(Space.xs))
+                                    Text("Manual download")
+                                }
+                            }
+                        }
+                        else -> Unit
                     }
                 }
             }
@@ -249,12 +286,22 @@ private fun McpUiState.message(port: Int): String = when (this) {
 
 private val UpdateUiState.message: String
     get() = when (this) {
-        UpdateUiState.NotChecked -> "Check GitHub Releases for a newer Daemonitor installer. Nothing is installed without approval."
+        UpdateUiState.NotChecked -> "Check GitHub Releases for a newer Daemonitor version. Updates are never installed without your approval."
         UpdateUiState.Checking -> "Checking GitHub Releases..."
         is UpdateUiState.UpToDate -> "Daemonitor is up to date at v$version."
-        is UpdateUiState.Available -> "v${candidate.version} is available. Daemonitor will download and verify ${candidate.assetName} before opening it."
+        is UpdateUiState.Available -> when (candidate.installMode) {
+            io.github.cdsap.daemonitor.update.UpdateInstallMode.Automatic ->
+                "v${candidate.version} is available for ${candidate.platform.metadataName}/${candidate.architecture.token}. Download stages the update while Daemonitor keeps running."
+            io.github.cdsap.daemonitor.update.UpdateInstallMode.Manual ->
+                "v${candidate.version} is available. Automatic installation is not supported for this install; Daemonitor can download and open ${candidate.assetName}."
+        }
         is UpdateUiState.Downloading -> progress?.let { "Downloading ${candidate.assetName}: ${(it * 100).toInt()}%." }
             ?: "Downloading ${candidate.assetName}..."
-        is UpdateUiState.ReadyToInstall -> "Downloaded and opened ${candidate.assetName}. Finish the installer to update Daemonitor."
+        is UpdateUiState.ReadyToInstall -> when {
+            candidate.installMode == io.github.cdsap.daemonitor.update.UpdateInstallMode.Automatic && staged != null ->
+                "Daemonitor ${candidate.version} is ready to install."
+            else ->
+                "Downloaded and opened ${candidate.assetName}. Finish the installer to update Daemonitor."
+        }
         is UpdateUiState.Failed -> message
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -3,11 +3,17 @@ package io.github.cdsap.daemonitor.ui.settings
 import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
 import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
 import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import io.github.cdsap.daemonitor.update.StagedUpdate
+import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCandidate
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstallMode
 import io.github.cdsap.daemonitor.update.UpdateInstaller
+import java.awt.Desktop
+import java.net.URI
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -48,8 +54,11 @@ sealed interface UpdateUiState {
     data class UpToDate(val version: String) : UpdateUiState
     data class Available(val candidate: UpdateCandidate) : UpdateUiState
     data class Downloading(val candidate: UpdateCandidate, val progress: Double?) : UpdateUiState
-    data class ReadyToInstall(val candidate: UpdateCandidate) : UpdateUiState
-    data class Failed(val message: String) : UpdateUiState
+    data class ReadyToInstall(
+        val candidate: UpdateCandidate,
+        val staged: StagedUpdate? = null,
+    ) : UpdateUiState
+    data class Failed(val message: String, val releaseUrl: String? = null) : UpdateUiState
 }
 
 /**
@@ -65,6 +74,9 @@ class SettingsViewModel(
         GitHubReleaseUpdateSource().check(BuildInfo.current.version)
     },
     private val updateInstaller: UpdateInstaller = DesktopUpdateInstaller(),
+    private val updateApplier: UpdateApplier = DesktopUpdateApplier(),
+    private val onExitForUpdate: () -> Unit = { kotlin.system.exitProcess(0) },
+    private val releaseOpener: (String) -> Unit = ::openReleaseUrl,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
 ) {
     private val _state = MutableStateFlow(initial)
@@ -123,19 +135,68 @@ class SettingsViewModel(
         _state.value = _state.value.copy(updateState = UpdateUiState.Downloading(candidate, 0.0))
         scope.launch {
             runCatching {
-                updateInstaller.open(candidate) { progress ->
+                updateInstaller.prepare(candidate) { progress ->
                     _state.value = _state.value.copy(updateState = UpdateUiState.Downloading(candidate, progress))
                 }
-            }.onSuccess {
-                _state.value = _state.value.copy(updateState = UpdateUiState.ReadyToInstall(candidate))
+            }.onSuccess { staged ->
+                _state.value = _state.value.copy(
+                    updateState = UpdateUiState.ReadyToInstall(candidate, staged),
+                )
             }.onFailure { error ->
                 _state.value = _state.value.copy(
                     updateState = UpdateUiState.Failed(
-                        error.message ?: error::class.simpleName ?: "Could not open the update",
+                        message = error.message ?: error::class.simpleName ?: "Could not prepare the update",
+                        releaseUrl = candidate.releaseUrl,
                     ),
                 )
             }
         }
+    }
+
+    fun restartAndUpdate() {
+        val ready = _state.value.updateState as? UpdateUiState.ReadyToInstall ?: return
+        val staged = ready.staged
+        if (staged == null || ready.candidate.installMode != UpdateInstallMode.Automatic) {
+            _state.value = _state.value.copy(
+                updateState = UpdateUiState.Failed(
+                    message = "Automatic installation is not available for this update. Use the manual download instead.",
+                    releaseUrl = ready.candidate.releaseUrl,
+                ),
+            )
+            return
+        }
+        runCatching {
+            updateApplier.applyAfterExit(staged)
+            onExitForUpdate()
+        }.onFailure { error ->
+            _state.value = _state.value.copy(
+                updateState = UpdateUiState.Failed(
+                    message = error.message ?: error::class.simpleName ?: "Could not restart to update",
+                    releaseUrl = ready.candidate.releaseUrl,
+                ),
+            )
+        }
+    }
+
+    fun openManualDownload(url: String? = releaseUrlFromState()) {
+        val target = url ?: return
+        runCatching { releaseOpener(target) }
+            .onFailure { error ->
+                _state.value = _state.value.copy(
+                    updateState = UpdateUiState.Failed(
+                        message = error.message ?: error::class.simpleName ?: "Could not open the release page",
+                        releaseUrl = target,
+                    ),
+                )
+            }
+    }
+
+    private fun releaseUrlFromState(): String? = when (val state = _state.value.updateState) {
+        is UpdateUiState.Available -> state.candidate.releaseUrl
+        is UpdateUiState.Downloading -> state.candidate.releaseUrl
+        is UpdateUiState.ReadyToInstall -> state.candidate.releaseUrl
+        is UpdateUiState.Failed -> state.releaseUrl
+        else -> null
     }
 
     private fun UpdateCheckResult.toUiState(): UpdateUiState = when (this) {
@@ -144,4 +205,11 @@ class SettingsViewModel(
         is UpdateCheckResult.UnsupportedPlatform -> UpdateUiState.Failed("Updates are not available for this platform yet")
         is UpdateCheckResult.Failed -> UpdateUiState.Failed(reason)
     }
+}
+
+private fun openReleaseUrl(url: String) {
+    require(Desktop.isDesktopSupported()) { "Desktop integration is not available" }
+    val desktop = Desktop.getDesktop()
+    require(desktop.isSupported(Desktop.Action.BROWSE)) { "Opening release pages is not supported" }
+    desktop.browse(URI(url))
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/CpuArchitecture.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/CpuArchitecture.kt
@@ -1,0 +1,41 @@
+package io.github.cdsap.daemonitor.update
+
+enum class CpuArchitecture(val token: String) {
+    X64("x64"),
+    ARM64("arm64"),
+    UNKNOWN("unknown"),
+    ;
+
+    companion object {
+        fun current(
+            osArch: String = System.getProperty("os.arch"),
+            osName: String = System.getProperty("os.name"),
+        ): CpuArchitecture {
+            val detected = from(osArch)
+            // Under Rosetta, Java reports x86_64; prefer the host CPU for artifact selection.
+            if (detected == X64 && osName.lowercase().contains("mac") && isAppleSiliconHost()) {
+                return ARM64
+            }
+            return detected
+        }
+
+        fun from(osArch: String): CpuArchitecture {
+            val arch = osArch.lowercase()
+            return when {
+                arch == "aarch64" || arch == "arm64" -> ARM64
+                arch == "amd64" || arch == "x86_64" || arch == "x64" -> X64
+                arch.startsWith("arm") -> ARM64
+                else -> UNKNOWN
+            }
+        }
+
+        private fun isAppleSiliconHost(): Boolean =
+            runCatching {
+                val process = ProcessBuilder("sysctl", "-n", "hw.optional.arm64")
+                    .redirectErrorStream(true)
+                    .start()
+                val output = process.inputStream.bufferedReader().use { it.readText() }.trim()
+                process.waitFor() == 0 && output == "1"
+            }.getOrDefault(false)
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatform.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatform.kt
@@ -1,11 +1,30 @@
 package io.github.cdsap.daemonitor.update
 
-enum class DesktopPlatform(val assetSuffix: String) {
-    MACOS("-macos.dmg"),
-    WINDOWS("-windows.msi"),
-    LINUX("-linux.deb"),
-    UNKNOWN(""),
+enum class DesktopPlatform(val metadataName: String) {
+    MACOS("macos"),
+    WINDOWS("windows"),
+    LINUX("linux"),
+    UNKNOWN("unknown"),
     ;
+
+    val installerExtension: String
+        get() = when (this) {
+            MACOS -> "dmg"
+            WINDOWS -> "msi"
+            LINUX -> "deb"
+            UNKNOWN -> ""
+        }
+
+    val updatePackageExtension: String
+        get() = when (this) {
+            MACOS, WINDOWS -> "zip"
+            LINUX -> "tar.gz"
+            UNKNOWN -> ""
+        }
+
+    /** Legacy Phase 1 suffix without architecture. */
+    val legacyInstallerSuffix: String
+        get() = "-$metadataName.$installerExtension"
 
     companion object {
         fun current(osName: String = System.getProperty("os.name")): DesktopPlatform {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/GitHubReleaseUpdateSource.kt
@@ -10,10 +10,15 @@ import kotlinx.coroutines.withContext
 class GitHubReleaseUpdateSource(
     private val repository: String = "cdsap/daemonitor",
     private val platform: DesktopPlatform = DesktopPlatform.current(),
+    private val architecture: CpuArchitecture = CpuArchitecture.current(),
+    private val installation: InstallationInfo = InstallationLocator.current(
+        platform = platform,
+        architecture = architecture,
+    ),
     private val client: HttpClient = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build(),
 ) {
     suspend fun check(currentVersion: String): UpdateCheckResult = withContext(Dispatchers.IO) {
-        if (platform == DesktopPlatform.UNKNOWN) {
+        if (platform == DesktopPlatform.UNKNOWN || architecture == CpuArchitecture.UNKNOWN) {
             return@withContext UpdateCheckResult.UnsupportedPlatform(platform)
         }
 
@@ -34,9 +39,22 @@ class GitHubReleaseUpdateSource(
                 fetchUpdateMetadata(asset.downloadUrl)
             }
             if (metadata != null) {
-                ReleaseMetadataUpdateSelector.select(metadata, release.releaseUrl, currentVersion, platform)
+                ReleaseMetadataUpdateSelector.select(
+                    metadata = metadata,
+                    releaseUrl = release.releaseUrl,
+                    currentVersion = currentVersion,
+                    platform = platform,
+                    architecture = architecture,
+                    installation = installation,
+                )
             } else {
-                ReleaseUpdateSelector.select(release, currentVersion, platform)
+                ReleaseUpdateSelector.select(
+                    release = release,
+                    currentVersion = currentVersion,
+                    platform = platform,
+                    architecture = architecture,
+                    installation = installation,
+                )
             }
         }.getOrElse { error ->
             UpdateCheckResult.Failed(error.message ?: error::class.simpleName ?: "Update check failed")
@@ -69,6 +87,7 @@ internal data class GitHubRelease(
 internal data class GitHubReleaseAsset(val name: String, val downloadUrl: String)
 
 internal data class ReleaseUpdateMetadata(
+    val schemaVersion: Int,
     val version: String,
     val tag: String,
     val assets: List<ReleaseUpdateAsset>,
@@ -80,6 +99,8 @@ internal data class ReleaseUpdateAsset(
     val url: String,
     val sha256: String,
     val sizeBytes: Long,
+    val arch: String? = null,
+    val role: String? = null,
 )
 
 internal object ReleaseMetadataUpdateSelector {
@@ -88,33 +109,89 @@ internal object ReleaseMetadataUpdateSelector {
         releaseUrl: String,
         currentVersion: String,
         platform: DesktopPlatform,
+        architecture: CpuArchitecture = CpuArchitecture.UNKNOWN,
+        installation: InstallationInfo = InstallationInfo(
+            platform = platform,
+            architecture = architecture,
+            kind = InstallationKind.UNSUPPORTED,
+            installRoot = null,
+            relaunchCommand = emptyList(),
+        ),
     ): UpdateCheckResult {
-        val asset = metadata.assets.firstOrNull { it.platform == platform.metadataName }
-            ?: return UpdateCheckResult.Failed("No ${platform.name.lowercase()} installer was listed in ${metadata.tag}")
-
-        return if (VersionComparator.isNewer(metadata.version, currentVersion)) {
-            UpdateCheckResult.Available(
-                UpdateCandidate(
-                    version = metadata.version,
-                    releaseUrl = releaseUrl,
-                    assetName = asset.fileName,
-                    downloadUrl = asset.url,
-                    sha256 = asset.sha256,
-                    sizeBytes = asset.sizeBytes,
-                ),
-            )
-        } else {
-            UpdateCheckResult.UpToDate(currentVersion)
+        if (!VersionComparator.isNewer(metadata.version, currentVersion)) {
+            return UpdateCheckResult.UpToDate(currentVersion)
         }
+
+        val named = metadata.assets.map { asset ->
+            NamedReleaseAsset(
+                fileName = asset.fileName,
+                downloadUrl = asset.url,
+                sha256 = asset.sha256,
+                sizeBytes = asset.sizeBytes,
+                platform = asset.platform,
+                architecture = asset.arch,
+                role = asset.role,
+            )
+        }
+        val preferAutomatic = installation.supportsAutomaticUpdate
+        val selected = selectFromMetadata(named, platform, architecture, preferAutomatic)
+            ?: return UpdateCheckResult.Failed(
+                "No ${platform.metadataName}/${architecture.token} update artifact was listed in ${metadata.tag}",
+            )
+
+        return UpdateCheckResult.Available(
+            toCandidate(
+                version = metadata.version,
+                releaseUrl = releaseUrl,
+                asset = selected,
+                platform = platform,
+                architecture = architecture,
+                installation = installation,
+            ),
+        )
     }
 
-    private val DesktopPlatform.metadataName: String
-        get() = when (this) {
-            DesktopPlatform.MACOS -> "macos"
-            DesktopPlatform.WINDOWS -> "windows"
-            DesktopPlatform.LINUX -> "linux"
-            DesktopPlatform.UNKNOWN -> "unknown"
+    private fun selectFromMetadata(
+        assets: List<NamedReleaseAsset>,
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+        preferAutomatic: Boolean,
+    ): NamedReleaseAsset? {
+        val platformAssets = assets.filter { asset ->
+            asset.platform.equals(platform.metadataName, ignoreCase = true) ||
+                UpdateArtifactMatcher.matchesPlatform(asset.fileName, platform)
+        }.filter { asset ->
+            val archToken = asset.architecture?.lowercase()
+            when {
+                archToken.isNullOrBlank() || archToken == "unknown" ->
+                    UpdateArtifactMatcher.matchesArchitecture(asset.fileName, architecture)
+                architecture == CpuArchitecture.UNKNOWN -> true
+                architecture == CpuArchitecture.ARM64 ->
+                    archToken in setOf("arm64", "aarch64")
+                architecture == CpuArchitecture.X64 ->
+                    archToken in setOf("x64", "amd64", "x86_64")
+                else -> false
+            }
         }
+        if (platformAssets.isEmpty()) return null
+
+        fun role(asset: NamedReleaseAsset): UpdateArtifactRole =
+            when (asset.role?.lowercase()) {
+                "update", "update_package", "package" -> UpdateArtifactRole.UpdatePackage
+                "installer" -> UpdateArtifactRole.Installer
+                else -> UpdateArtifactMatcher.roleOf(asset.fileName)
+            }
+
+        val updatePackages = platformAssets.filter { role(it) == UpdateArtifactRole.UpdatePackage }
+        val installers = platformAssets.filter { role(it) == UpdateArtifactRole.Installer }
+        return if (preferAutomatic) {
+            UpdateArtifactMatcher.selectAsset(updatePackages.ifEmpty { platformAssets }, platform, architecture, preferAutomatic = true)
+                ?: UpdateArtifactMatcher.selectAsset(installers, platform, architecture, preferAutomatic = false)
+        } else {
+            UpdateArtifactMatcher.selectAsset(installers.ifEmpty { platformAssets }, platform, architecture, preferAutomatic = false)
+                ?: UpdateArtifactMatcher.selectAsset(updatePackages, platform, architecture, preferAutomatic = true)
+        }
+    }
 }
 
 internal object ReleaseUpdateSelector {
@@ -122,23 +199,82 @@ internal object ReleaseUpdateSelector {
         release: GitHubRelease,
         currentVersion: String,
         platform: DesktopPlatform,
+        architecture: CpuArchitecture = CpuArchitecture.UNKNOWN,
+        installation: InstallationInfo = InstallationInfo(
+            platform = platform,
+            architecture = architecture,
+            kind = InstallationKind.UNSUPPORTED,
+            installRoot = null,
+            relaunchCommand = emptyList(),
+        ),
     ): UpdateCheckResult {
-        val asset = release.assets.firstOrNull { it.name.endsWith(platform.assetSuffix) }
-            ?: return UpdateCheckResult.Failed("No ${platform.name.lowercase()} installer was attached to ${release.version}")
-
-        return if (VersionComparator.isNewer(release.version, currentVersion)) {
-            UpdateCheckResult.Available(
-                UpdateCandidate(
-                    version = release.version.removePrefix("v").removePrefix("V"),
-                    releaseUrl = release.releaseUrl,
-                    assetName = asset.name,
-                    downloadUrl = asset.downloadUrl,
-                ),
-            )
-        } else {
-            UpdateCheckResult.UpToDate(currentVersion)
+        if (!VersionComparator.isNewer(release.version, currentVersion)) {
+            return UpdateCheckResult.UpToDate(currentVersion)
         }
+
+        val named = release.assets.map { NamedReleaseAsset(it.name, it.downloadUrl) }
+        val selected = UpdateArtifactMatcher.selectAsset(
+            assets = named,
+            platform = platform,
+            architecture = architecture,
+            preferAutomatic = installation.supportsAutomaticUpdate,
+        ) ?: return UpdateCheckResult.Failed(
+            "No ${platform.metadataName} installer was attached to ${release.version}",
+        )
+
+        return UpdateCheckResult.Available(
+            toCandidate(
+                version = release.version.removePrefix("v").removePrefix("V"),
+                releaseUrl = release.releaseUrl,
+                asset = selected,
+                platform = platform,
+                architecture = architecture,
+                installation = installation,
+            ),
+        )
     }
+}
+
+private fun toCandidate(
+    version: String,
+    releaseUrl: String,
+    asset: NamedReleaseAsset,
+    platform: DesktopPlatform,
+    architecture: CpuArchitecture,
+    installation: InstallationInfo,
+): UpdateCandidate {
+    val role = when (asset.role?.lowercase()) {
+        "update", "update_package", "package" -> UpdateArtifactRole.UpdatePackage
+        "installer" -> UpdateArtifactRole.Installer
+        else -> UpdateArtifactMatcher.roleOf(asset.fileName)
+    }
+    val detectedArch = asset.architecture?.let {
+        when (it.lowercase()) {
+            "arm64", "aarch64" -> CpuArchitecture.ARM64
+            "x64", "amd64", "x86_64" -> CpuArchitecture.X64
+            else -> null
+        }
+    } ?: UpdateArtifactMatcher.architectureOf(asset.fileName).takeIf { it != CpuArchitecture.UNKNOWN }
+        ?: architecture
+
+    val installMode = when {
+        role == UpdateArtifactRole.UpdatePackage && installation.supportsAutomaticUpdate ->
+            UpdateInstallMode.Automatic
+        else -> UpdateInstallMode.Manual
+    }
+
+    return UpdateCandidate(
+        version = version,
+        releaseUrl = releaseUrl,
+        assetName = asset.fileName,
+        downloadUrl = asset.downloadUrl,
+        sha256 = asset.sha256,
+        sizeBytes = asset.sizeBytes,
+        platform = platform,
+        architecture = detectedArch,
+        role = role,
+        installMode = installMode,
+    )
 }
 
 internal object GitHubReleaseJsonParser {
@@ -171,7 +307,7 @@ internal object GitHubReleaseJsonParser {
 internal object ReleaseUpdateMetadataJsonParser {
     fun parse(json: String): ReleaseUpdateMetadata? {
         val schemaVersion = json.intField("schemaVersion") ?: return null
-        if (schemaVersion != 1) return null
+        if (schemaVersion !in 1..2) return null
         val version = json.stringField("version") ?: return null
         val tag = json.stringField("tag") ?: return null
         val assetsJson = json.arrayField("assets") ?: return null
@@ -184,10 +320,17 @@ internal object ReleaseUpdateMetadataJsonParser {
                 url = assetJson.stringField("url") ?: return@mapNotNull null,
                 sha256 = sha256,
                 sizeBytes = assetJson.longField("size") ?: return@mapNotNull null,
+                arch = assetJson.stringField("arch"),
+                role = assetJson.stringField("role"),
             )
         }.toList()
         if (assets.isEmpty()) return null
-        return ReleaseUpdateMetadata(version = version, tag = tag, assets = assets)
+        return ReleaseUpdateMetadata(
+            schemaVersion = schemaVersion,
+            version = version,
+            tag = tag,
+            assets = assets,
+        )
     }
 
     private fun String.stringField(name: String): String? {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/InstallationLocator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/InstallationLocator.kt
@@ -1,0 +1,210 @@
+package io.github.cdsap.daemonitor.update
+
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isWritable
+
+/**
+ * Describes how the currently running Daemonitor binary is installed and whether the app can safely
+ * replace that installation after a clean exit.
+ */
+data class InstallationInfo(
+    val platform: DesktopPlatform,
+    val architecture: CpuArchitecture,
+    val kind: InstallationKind,
+    val installRoot: Path?,
+    val relaunchCommand: List<String>,
+) {
+    val supportsAutomaticUpdate: Boolean
+        get() = when (kind) {
+            InstallationKind.MACOS_APP_BUNDLE,
+            InstallationKind.WINDOWS_APP_DIR,
+            InstallationKind.LINUX_STANDALONE -> installRoot != null && relaunchCommand.isNotEmpty()
+            InstallationKind.LINUX_PACKAGE_MANAGED,
+            InstallationKind.DEVELOPMENT,
+            InstallationKind.UNSUPPORTED -> false
+        }
+
+    val manualUpdateReason: String?
+        get() = when (kind) {
+            InstallationKind.LINUX_PACKAGE_MANAGED ->
+                "This Linux installation is managed by the system package manager. Download the newer package and install it with your package manager."
+            InstallationKind.DEVELOPMENT ->
+                "This development launch cannot replace an installed application. Download the release artifact and install it manually."
+            InstallationKind.UNSUPPORTED ->
+                "Automatic updates are not supported for this installation. Download the release artifact and install it manually."
+            else -> if (supportsAutomaticUpdate) null else
+                "Automatic updates are not available for this installation. Download the release artifact and install it manually."
+        }
+}
+
+enum class InstallationKind {
+    MACOS_APP_BUNDLE,
+    WINDOWS_APP_DIR,
+    LINUX_STANDALONE,
+    LINUX_PACKAGE_MANAGED,
+    DEVELOPMENT,
+    UNSUPPORTED,
+}
+
+object InstallationLocator {
+    fun current(
+        platform: DesktopPlatform = DesktopPlatform.current(),
+        architecture: CpuArchitecture = CpuArchitecture.current(),
+        executable: String? = ProcessHandle.current().info().command().orElse(null),
+        javaHome: String = System.getProperty("java.home"),
+        classpath: String = System.getProperty("java.class.path"),
+        packageManagedProbe: (Path) -> Boolean = ::isLinuxPackageManaged,
+    ): InstallationInfo {
+        val command = executable?.takeIf { it.isNotBlank() }
+        if (command != null && !command.isJavaExecutable()) {
+            return when (platform) {
+                DesktopPlatform.MACOS -> macInstallation(command, platform, architecture)
+                DesktopPlatform.WINDOWS -> windowsInstallation(command, platform, architecture)
+                DesktopPlatform.LINUX -> linuxInstallation(command, platform, architecture, packageManagedProbe)
+                DesktopPlatform.UNKNOWN -> unsupported(platform, architecture)
+            }
+        }
+
+        // Source / IDE launches use the system java launcher and cannot safely replace an install.
+        return InstallationInfo(
+            platform = platform,
+            architecture = architecture,
+            kind = InstallationKind.DEVELOPMENT,
+            installRoot = null,
+            relaunchCommand = listOf(
+                javaExecutablePath(javaHome, platform),
+                "-cp",
+                classpath,
+                "io.github.cdsap.daemonitor.Daemonitor",
+            ),
+        )
+    }
+
+    private fun macInstallation(
+        executable: String,
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+    ): InstallationInfo {
+        val appPath = executable.macAppBundlePath()?.let(Path::of)
+        if (appPath != null) {
+            return InstallationInfo(
+                platform = platform,
+                architecture = architecture,
+                kind = InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = appPath,
+                relaunchCommand = listOf("/usr/bin/open", "-n", appPath.toString()),
+            )
+        }
+        return unsupported(platform, architecture)
+    }
+
+    private fun windowsInstallation(
+        executable: String,
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+    ): InstallationInfo {
+        val exePath = Path.of(executable)
+        val installRoot = exePath.parent
+        if (installRoot != null) {
+            return InstallationInfo(
+                platform = platform,
+                architecture = architecture,
+                kind = InstallationKind.WINDOWS_APP_DIR,
+                installRoot = installRoot,
+                relaunchCommand = listOf(exePath.toString()),
+            )
+        }
+        return unsupported(platform, architecture)
+    }
+
+    private fun linuxInstallation(
+        executable: String,
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+        packageManagedProbe: (Path) -> Boolean,
+    ): InstallationInfo {
+        val exePath = Path.of(executable).toAbsolutePath().normalize()
+        val installRoot = resolveLinuxInstallRoot(exePath) ?: return unsupported(platform, architecture)
+        if (packageManagedProbe(exePath) || packageManagedProbe(installRoot)) {
+            return InstallationInfo(
+                platform = platform,
+                architecture = architecture,
+                kind = InstallationKind.LINUX_PACKAGE_MANAGED,
+                installRoot = installRoot,
+                relaunchCommand = listOf(exePath.toString()),
+            )
+        }
+        val writable = installRoot.isWritable() || installRoot.parent?.isWritable() == true
+        if (!writable) {
+            return InstallationInfo(
+                platform = platform,
+                architecture = architecture,
+                kind = InstallationKind.UNSUPPORTED,
+                installRoot = installRoot,
+                relaunchCommand = listOf(exePath.toString()),
+            )
+        }
+        return InstallationInfo(
+            platform = platform,
+            architecture = architecture,
+            kind = InstallationKind.LINUX_STANDALONE,
+            installRoot = installRoot,
+            relaunchCommand = listOf(exePath.toString()),
+        )
+    }
+
+    private fun resolveLinuxInstallRoot(executable: Path): Path? {
+        val parent = executable.parent ?: return null
+        // jpackage layout: <root>/bin/Daemonitor
+        if (parent.fileName?.toString() == "bin") {
+            val root = parent.parent
+            if (root != null && root.resolve("lib").isDirectory()) return root
+        }
+        return parent
+    }
+
+    private fun unsupported(
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+    ): InstallationInfo = InstallationInfo(
+        platform = platform,
+        architecture = architecture,
+        kind = InstallationKind.UNSUPPORTED,
+        installRoot = null,
+        relaunchCommand = emptyList(),
+    )
+
+    private fun isLinuxPackageManaged(path: Path): Boolean {
+        val normalized = path.toAbsolutePath().normalize().toString()
+        if (normalized.startsWith("/usr/") || normalized == "/usr") return true
+        return runCatching {
+            val process = ProcessBuilder("dpkg", "-S", normalized)
+                .redirectErrorStream(true)
+                .start()
+            val output = process.inputStream.bufferedReader().use { it.readText() }
+            process.waitFor() == 0 && output.contains("daemonitor", ignoreCase = true)
+        }.getOrDefault(false)
+    }
+
+    private fun String.isJavaExecutable(): Boolean {
+        val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
+        return name == "java" || name == "java.exe"
+    }
+
+    private fun String.macAppBundlePath(): String? {
+        val marker = ".app/Contents/MacOS/"
+        val index = indexOf(marker)
+        if (index < 0) return null
+        return substring(0, index + ".app".length)
+    }
+
+    private fun javaExecutablePath(javaHome: String, platform: DesktopPlatform): String {
+        val name = if (platform == DesktopPlatform.WINDOWS) "java.exe" else "java"
+        return if (platform == DesktopPlatform.WINDOWS) {
+            "${javaHome.trimEnd('\\')}\\bin\\$name"
+        } else {
+            "${javaHome.trimEnd('/')}/bin/$name"
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/InstallationLocator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/InstallationLocator.kt
@@ -86,14 +86,14 @@ object InstallationLocator {
         platform: DesktopPlatform,
         architecture: CpuArchitecture,
     ): InstallationInfo {
-        val appPath = executable.macAppBundlePath()?.let(Path::of)
+        val appPath = executable.macAppBundlePath()
         if (appPath != null) {
             return InstallationInfo(
                 platform = platform,
                 architecture = architecture,
                 kind = InstallationKind.MACOS_APP_BUNDLE,
-                installRoot = appPath,
-                relaunchCommand = listOf("/usr/bin/open", "-n", appPath.toString()),
+                installRoot = Path.of(appPath),
+                relaunchCommand = listOf("/usr/bin/open", "-n", appPath),
             )
         }
         return unsupported(platform, architecture)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateArtifactMatcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateArtifactMatcher.kt
@@ -1,0 +1,112 @@
+package io.github.cdsap.daemonitor.update
+
+/**
+ * Selects the best release artifact for the current OS/arch and installation capabilities.
+ *
+ * Preference order when automatic updates are supported:
+ * 1. platform+arch update package (zip/tar.gz)
+ * 2. platform-only update package
+ * 3. platform+arch installer (manual fallback)
+ * 4. platform-only installer
+ *
+ * Preference order when automatic updates are not supported:
+ * 1. platform+arch installer
+ * 2. platform-only installer
+ * 3. matching update package offered as a manual download
+ */
+internal object UpdateArtifactMatcher {
+    fun selectAsset(
+        assets: List<NamedReleaseAsset>,
+        platform: DesktopPlatform,
+        architecture: CpuArchitecture,
+        preferAutomatic: Boolean,
+    ): NamedReleaseAsset? {
+        if (platform == DesktopPlatform.UNKNOWN) return null
+        val matching = assets.filter { asset ->
+            matchesPlatform(asset.fileName, platform) && matchesArchitecture(asset.fileName, architecture)
+        }
+        if (matching.isEmpty()) return null
+
+        val updatePackages = matching.filter { roleOf(it.fileName) == UpdateArtifactRole.UpdatePackage }
+        val installers = matching.filter { roleOf(it.fileName) == UpdateArtifactRole.Installer }
+
+        return if (preferAutomatic) {
+            preferred(updatePackages, architecture)
+                ?: preferred(installers, architecture)
+                ?: matching.firstOrNull()
+        } else {
+            preferred(installers, architecture)
+                ?: preferred(updatePackages, architecture)
+                ?: matching.firstOrNull()
+        }
+    }
+
+    fun roleOf(fileName: String): UpdateArtifactRole {
+        val lower = fileName.lowercase()
+        return when {
+            lower.endsWith(".zip") || lower.endsWith(".tar.gz") || lower.endsWith(".tgz") ->
+                UpdateArtifactRole.UpdatePackage
+            else -> UpdateArtifactRole.Installer
+        }
+    }
+
+    fun matchesPlatform(fileName: String, platform: DesktopPlatform): Boolean {
+        val lower = fileName.lowercase()
+        val token = "-${platform.metadataName}"
+        if (!lower.contains(token)) return false
+        // Reject checksum sidecars and metadata.
+        if (lower.endsWith(".sha256") || lower.endsWith(".json") || lower.endsWith(".txt")) return false
+        return true
+    }
+
+    fun matchesArchitecture(fileName: String, architecture: CpuArchitecture): Boolean {
+        if (architecture == CpuArchitecture.UNKNOWN) return true
+        val lower = fileName.lowercase()
+        val hasArchToken = ARCH_TOKENS.any { token -> "-$token" in lower || ".$token." in lower }
+        if (!hasArchToken) return true // legacy assets without arch are acceptable fallbacks
+        return when (architecture) {
+            CpuArchitecture.ARM64 ->
+                lower.contains("-arm64") || lower.contains("-aarch64") || lower.contains(".arm64.")
+            CpuArchitecture.X64 ->
+                lower.contains("-x64") || lower.contains("-amd64") || lower.contains("-x86_64") ||
+                    lower.contains(".x64.")
+            CpuArchitecture.UNKNOWN -> true
+        }
+    }
+
+    fun architectureOf(fileName: String): CpuArchitecture {
+        val lower = fileName.lowercase()
+        return when {
+            lower.contains("-arm64") || lower.contains("-aarch64") || lower.contains(".arm64.") ->
+                CpuArchitecture.ARM64
+            lower.contains("-x64") || lower.contains("-amd64") || lower.contains("-x86_64") ||
+                lower.contains(".x64.") -> CpuArchitecture.X64
+            else -> CpuArchitecture.UNKNOWN
+        }
+    }
+
+    private fun preferred(
+        assets: List<NamedReleaseAsset>,
+        architecture: CpuArchitecture,
+    ): NamedReleaseAsset? {
+        if (assets.isEmpty()) return null
+        val archSpecific = assets.filter { architectureOf(it.fileName) == architecture }
+        if (architecture != CpuArchitecture.UNKNOWN && archSpecific.isNotEmpty()) {
+            return archSpecific.first()
+        }
+        val legacy = assets.filter { architectureOf(it.fileName) == CpuArchitecture.UNKNOWN }
+        return legacy.firstOrNull() ?: assets.first()
+    }
+
+    private val ARCH_TOKENS = listOf("arm64", "aarch64", "x64", "amd64", "x86_64")
+}
+
+internal data class NamedReleaseAsset(
+    val fileName: String,
+    val downloadUrl: String,
+    val sha256: String? = null,
+    val sizeBytes: Long? = null,
+    val platform: String? = null,
+    val architecture: String? = null,
+    val role: String? = null,
+)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateCandidate.kt
@@ -1,5 +1,18 @@
 package io.github.cdsap.daemonitor.update
 
+enum class UpdateInstallMode {
+    /** Download, validate, stage, then apply on Restart and Update. */
+    Automatic,
+
+    /** Download/verify when possible, then hand off to a manual installer or release page. */
+    Manual,
+}
+
+enum class UpdateArtifactRole {
+    UpdatePackage,
+    Installer,
+}
+
 data class UpdateCandidate(
     val version: String,
     val releaseUrl: String,
@@ -7,6 +20,10 @@ data class UpdateCandidate(
     val downloadUrl: String,
     val sha256: String? = null,
     val sizeBytes: Long? = null,
+    val platform: DesktopPlatform = DesktopPlatform.UNKNOWN,
+    val architecture: CpuArchitecture = CpuArchitecture.UNKNOWN,
+    val role: UpdateArtifactRole = UpdateArtifactRole.Installer,
+    val installMode: UpdateInstallMode = UpdateInstallMode.Manual,
 )
 
 sealed interface UpdateCheckResult {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
@@ -8,24 +8,193 @@ import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.security.MessageDigest
+import java.util.zip.ZipInputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlin.io.path.outputStream
 
+data class StagedUpdate(
+    val candidate: UpdateCandidate,
+    val artifactPath: Path,
+    val payloadPath: Path,
+    val installation: InstallationInfo,
+)
+
 fun interface UpdateInstaller {
-    suspend fun open(candidate: UpdateCandidate, onProgress: (Double?) -> Unit)
+    suspend fun prepare(candidate: UpdateCandidate, onProgress: (Double?) -> Unit): StagedUpdate?
 }
 
 class DesktopUpdateInstaller(
     private val updateDirectory: Path = Defaults.APP_SUPPORT_DIR.resolve("updates"),
+    private val installation: InstallationInfo = InstallationLocator.current(),
     private val opener: (Path) -> Unit = ::openWithDesktop,
     private val downloader: suspend (UpdateCandidate, Path, (Double?) -> Unit) -> Path = ::downloadAndVerify,
 ) : UpdateInstaller {
-    override suspend fun open(candidate: UpdateCandidate, onProgress: (Double?) -> Unit) {
-        val installer = downloader(candidate, updateDirectory, onProgress)
-        opener(installer)
+    override suspend fun prepare(candidate: UpdateCandidate, onProgress: (Double?) -> Unit): StagedUpdate? {
+        validateCandidate(candidate)
+        val artifact = downloader(candidate, updateDirectory, onProgress)
+        return when (candidate.installMode) {
+            UpdateInstallMode.Automatic -> {
+                val payload = extractUpdatePayload(candidate, artifact, updateDirectory)
+                StagedUpdate(
+                    candidate = candidate,
+                    artifactPath = artifact,
+                    payloadPath = payload,
+                    installation = installation,
+                )
+            }
+            UpdateInstallMode.Manual -> {
+                opener(artifact)
+                null
+            }
+        }
     }
+
+    private fun validateCandidate(candidate: UpdateCandidate) {
+        require(candidate.platform == DesktopPlatform.UNKNOWN || candidate.platform == installation.platform) {
+            "Update artifact platform ${candidate.platform} does not match ${installation.platform}"
+        }
+        if (candidate.architecture != CpuArchitecture.UNKNOWN &&
+            installation.architecture != CpuArchitecture.UNKNOWN
+        ) {
+            require(candidate.architecture == installation.architecture) {
+                "Update artifact architecture ${candidate.architecture.token} does not match ${installation.architecture.token}"
+            }
+        }
+        if (candidate.installMode == UpdateInstallMode.Automatic) {
+            require(installation.supportsAutomaticUpdate) {
+                installation.manualUpdateReason ?: "Automatic updates are not supported for this installation"
+            }
+            require(candidate.role == UpdateArtifactRole.UpdatePackage) {
+                "Automatic updates require a zip/tar.gz update package"
+            }
+        }
+    }
+}
+
+fun interface UpdateApplier {
+    fun applyAfterExit(staged: StagedUpdate)
+}
+
+class DesktopUpdateApplier(
+    private val processId: Long = ProcessHandle.current().pid(),
+    private val processStarter: (List<String>, Path) -> Unit = ::startDetached,
+) : UpdateApplier {
+    override fun applyAfterExit(staged: StagedUpdate) {
+        val installRoot = staged.installation.installRoot
+            ?: error("Installation location is unknown; refusing to apply the update")
+        require(staged.installation.supportsAutomaticUpdate) {
+            staged.installation.manualUpdateReason ?: "Automatic updates are not supported"
+        }
+        require(Files.exists(staged.payloadPath)) {
+            "Staged update payload is missing; the application may have been moved"
+        }
+        require(Files.exists(installRoot)) {
+            "Installation location no longer exists; refusing to apply the update"
+        }
+
+        val helper = when (staged.installation.platform) {
+            DesktopPlatform.MACOS -> writeUnixHelper(staged, installRoot, mac = true)
+            DesktopPlatform.LINUX -> writeUnixHelper(staged, installRoot, mac = false)
+            DesktopPlatform.WINDOWS -> writeWindowsHelper(staged, installRoot)
+            DesktopPlatform.UNKNOWN -> error("Unsupported platform")
+        }
+
+        val command = when (staged.installation.platform) {
+            DesktopPlatform.WINDOWS -> listOf("cmd.exe", "/c", helper.toString())
+            else -> listOf("/bin/bash", helper.toString())
+        }
+        processStarter(command, helper.parent)
+    }
+
+    private fun writeUnixHelper(staged: StagedUpdate, installRoot: Path, mac: Boolean): Path {
+        val helper = staged.artifactPath.parent.resolve("apply-update.sh")
+        val relaunch = staged.installation.relaunchCommand.joinToString(" ") { shellEscape(it) }
+        val quarantine = if (mac) {
+            "xattr -dr com.apple.quarantine \"\$app_path\" >/dev/null 2>&1 || true"
+        } else {
+            "true"
+        }
+        val stagedDir = staged.artifactPath.parent.resolve("staged")
+        val script = """
+            #!/bin/bash
+            set -euo pipefail
+            pid=$processId
+            app_path=${shellEscape(installRoot.toString())}
+            staged=${shellEscape(staged.payloadPath.toString())}
+            backup="${"$"}{app_path}.pre-update"
+            while kill -0 "${"$"}pid" 2>/dev/null; do sleep 0.2; done
+            sleep 0.4
+            if [[ ! -e "${"$"}app_path" || ! -e "${"$"}staged" ]]; then
+              echo "Update apply aborted: installation or staged payload missing" >&2
+              exit 1
+            fi
+            rm -rf "${"$"}backup"
+            mv "${"$"}app_path" "${"$"}backup"
+            if ! mv "${"$"}staged" "${"$"}app_path"; then
+              mv "${"$"}backup" "${"$"}app_path"
+              echo "Update apply failed; restored the previous installation" >&2
+              exit 1
+            fi
+            $quarantine
+            $relaunch
+            rm -rf "${"$"}backup"
+            rm -rf ${shellEscape(stagedDir.toString())}
+            rm -f ${shellEscape(staged.artifactPath.toString())}
+            rm -f "${"$"}0"
+        """.trimIndent()
+        helper.writeExecutable(script)
+        return helper
+    }
+
+    private fun writeWindowsHelper(staged: StagedUpdate, installRoot: Path): Path {
+        val helper = staged.artifactPath.parent.resolve("apply-update.cmd")
+        val relaunch = staged.installation.relaunchCommand.joinToString(" ") { windowsQuote(it) }
+        val stagedDir = staged.artifactPath.parent.resolve("staged")
+        Files.writeString(
+            helper,
+            """
+            @echo off
+            setlocal
+            set PID=$processId
+            set APP_PATH=${windowsQuote(installRoot.toString())}
+            set STAGED=${windowsQuote(staged.payloadPath.toString())}
+            set BACKUP=%APP_PATH%.pre-update
+            :wait
+            tasklist /FI "PID eq %PID%" 2>NUL | find "%PID%" >NUL
+            if not errorlevel 1 (
+              timeout /t 1 /nobreak >NUL
+              goto wait
+            )
+            if not exist "%APP_PATH%" exit /b 1
+            if not exist "%STAGED%" exit /b 1
+            if exist "%BACKUP%" rmdir /s /q "%BACKUP%"
+            move /Y "%APP_PATH%" "%BACKUP%"
+            if errorlevel 1 exit /b 1
+            move /Y "%STAGED%" "%APP_PATH%"
+            if errorlevel 1 (
+              move /Y "%BACKUP%" "%APP_PATH%"
+              exit /b 1
+            )
+            start "" $relaunch
+            rmdir /s /q "%BACKUP%"
+            rmdir /s /q ${windowsQuote(stagedDir.toString())}
+            del /f /q ${windowsQuote(staged.artifactPath.toString())}
+            del /f /q "%~f0"
+            """.trimIndent(),
+        )
+        return helper
+    }
+}
+
+private fun startDetached(command: List<String>, workingDir: Path?) {
+    val builder = ProcessBuilder(command)
+    if (workingDir != null) builder.directory(workingDir.toFile())
+    builder.redirectOutput(ProcessBuilder.Redirect.DISCARD)
+    builder.redirectError(ProcessBuilder.Redirect.DISCARD)
+    builder.start()
 }
 
 private fun openWithDesktop(path: Path) {
@@ -44,6 +213,9 @@ private suspend fun downloadAndVerify(
         ?: error("Release checksum is unavailable; refusing to install ${candidate.assetName}")
     require(expectedSha256.matches(Regex("[a-fA-F0-9]{64}"))) {
         "Release checksum is invalid for ${candidate.assetName}"
+    }
+    require(candidate.downloadUrl.startsWith("https://github.com/cdsap/daemonitor/")) {
+        "Refusing to download an update from an unexpected host"
     }
 
     Files.createDirectories(updateDirectory)
@@ -89,12 +261,90 @@ private suspend fun downloadAndVerify(
     Files.move(
         tempPath,
         finalPath,
-        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-        java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        StandardCopyOption.REPLACE_EXISTING,
+        StandardCopyOption.ATOMIC_MOVE,
     )
     onProgress(1.0)
     finalPath
 }
+
+internal fun extractUpdatePayload(
+    candidate: UpdateCandidate,
+    artifact: Path,
+    updateDirectory: Path,
+): Path {
+    val extractRoot = updateDirectory.resolve("staged").resolve(candidate.version)
+    if (Files.exists(extractRoot)) {
+        extractRoot.toFile().deleteRecursively()
+    }
+    Files.createDirectories(extractRoot)
+
+    val lower = candidate.assetName.lowercase()
+    when {
+        lower.endsWith(".zip") -> unzip(artifact, extractRoot)
+        lower.endsWith(".tar.gz") || lower.endsWith(".tgz") -> untarGzip(artifact, extractRoot)
+        else -> error("Unsupported update package format: ${candidate.assetName}")
+    }
+
+    return findPayload(extractRoot, candidate.platform)
+        ?: error("Update package did not contain a Daemonitor application payload")
+}
+
+private fun findPayload(extractRoot: Path, platform: DesktopPlatform): Path? {
+    Files.walk(extractRoot).use { stream ->
+        val matches = stream.filter { path ->
+            when (platform) {
+                DesktopPlatform.MACOS ->
+                    path.fileName?.toString() == "Daemonitor.app" && Files.isDirectory(path)
+                DesktopPlatform.WINDOWS ->
+                    Files.isDirectory(path) && Files.isRegularFile(path.resolve("Daemonitor.exe"))
+                DesktopPlatform.LINUX ->
+                    Files.isDirectory(path) && (
+                        Files.isRegularFile(path.resolve("bin").resolve("Daemonitor")) ||
+                            Files.isRegularFile(path.resolve("Daemonitor"))
+                        )
+                DesktopPlatform.UNKNOWN -> false
+            }
+        }.toList()
+        return matches.minByOrNull { it.nameCount }
+    }
+}
+
+private fun unzip(archive: Path, target: Path) {
+    ZipInputStream(Files.newInputStream(archive)).use { zip ->
+        while (true) {
+            val entry = zip.nextEntry ?: break
+            val outPath = target.resolve(entry.name).normalize()
+            require(outPath.startsWith(target)) { "Refusing to extract path outside staging directory" }
+            if (entry.isDirectory) {
+                Files.createDirectories(outPath)
+            } else {
+                Files.createDirectories(outPath.parent)
+                Files.copy(zip, outPath, StandardCopyOption.REPLACE_EXISTING)
+            }
+            zip.closeEntry()
+        }
+    }
+}
+
+private fun untarGzip(archive: Path, target: Path) {
+    val result = ProcessBuilder("tar", "-xzf", archive.toString(), "-C", target.toString())
+        .redirectErrorStream(true)
+        .start()
+    val output = result.inputStream.bufferedReader().use { it.readText() }
+    check(result.waitFor() == 0) { "Failed to extract update archive: $output" }
+}
+
+private fun Path.writeExecutable(contents: String) {
+    Files.writeString(this, contents)
+    toFile().setExecutable(true, false)
+}
+
+private fun shellEscape(value: String): String =
+    "'" + value.replace("'", "'\"'\"'") + "'"
+
+private fun windowsQuote(value: String): String =
+    "\"${value.replace("\"", "\\\"")}\""
 
 internal object UpdateDownloadVerifier {
     fun matches(actualDigest: ByteArray, expectedSha256: String): Boolean =

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ReleaseMetadataTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ReleaseMetadataTest.kt
@@ -25,9 +25,12 @@ class ReleaseMetadataTest {
         val outputDir = tempDir.resolve("metadata")
 
         val assets = mapOf(
-            "Daemonitor-1.0.2-linux.deb" to "linux package",
-            "Daemonitor-1.0.2-windows.msi" to "windows package",
-            "Daemonitor-1.0.2-macos.dmg" to "macos package",
+            "Daemonitor-1.0.7-linux-x64.deb" to "linux package",
+            "Daemonitor-1.0.7-linux-x64.tar.gz" to "linux update",
+            "Daemonitor-1.0.7-windows-x64.msi" to "windows package",
+            "Daemonitor-1.0.7-windows-x64.zip" to "windows update",
+            "Daemonitor-1.0.7-macos-arm64.dmg" to "macos package",
+            "Daemonitor-1.0.7-macos-arm64.zip" to "macos update",
         )
         assets.forEach { (name, content) -> assetsDir.resolve(name).writeText(content) }
 
@@ -36,8 +39,8 @@ class ReleaseMetadataTest {
             "scripts/generate-release-metadata.sh",
             assetsDir.toString(),
             outputDir.toString(),
-            "1.0.2",
-            "v1.0.2",
+            "1.0.7",
+            "v1.0.7",
             "cdsap/daemonitor",
         )
             .redirectErrorStream(true)
@@ -50,22 +53,27 @@ class ReleaseMetadataTest {
         assets.keys.forEach { name ->
             val expected = sha256(assetsDir.resolve(name))
             assertTrue(checksums.contains("$expected  $name"), checksums)
+            assertEquals(expected + "\n", assetsDir.resolve("$name.sha256").readText())
         }
 
         val latest = outputDir.resolve("latest.json").readText()
-        assertTrue(latest.contains("\"schemaVersion\": 1"), latest)
-        assertTrue(latest.contains("\"version\": \"1.0.2\""), latest)
-        assertTrue(latest.contains("\"tag\": \"v1.0.2\""), latest)
+        assertTrue(latest.contains("\"schemaVersion\": 2"), latest)
+        assertTrue(latest.contains("\"version\": \"1.0.7\""), latest)
+        assertTrue(latest.contains("\"tag\": \"v1.0.7\""), latest)
         assertTrue(latest.contains("\"platform\": \"linux\""), latest)
         assertTrue(latest.contains("\"platform\": \"windows\""), latest)
         assertTrue(latest.contains("\"platform\": \"macos\""), latest)
+        assertTrue(latest.contains("\"arch\": \"arm64\""), latest)
+        assertTrue(latest.contains("\"arch\": \"x64\""), latest)
+        assertTrue(latest.contains("\"role\": \"update\""), latest)
+        assertTrue(latest.contains("\"role\": \"installer\""), latest)
         assertTrue(
             latest.contains(
-                "\"url\": \"https://github.com/cdsap/daemonitor/releases/download/v1.0.2/Daemonitor-1.0.2-macos.dmg\"",
+                "\"url\": \"https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-arm64.zip\"",
             ),
             latest,
         )
-        assertTrue(latest.contains("\"sha256\": \"${sha256(assetsDir.resolve("Daemonitor-1.0.2-linux.deb"))}\""), latest)
+        assertTrue(latest.contains("\"sha256\": \"${sha256(assetsDir.resolve("Daemonitor-1.0.7-linux-x64.deb"))}\""), latest)
 
         assertEquals(latest, outputDir.resolve("update.json").readText())
     }
@@ -75,12 +83,15 @@ class ReleaseMetadataTest {
         val workflow = Path.of(".github/workflows/release.yml").readText()
 
         assertTrue(workflow.contains("Read package version"), workflow)
+        assertTrue(workflow.contains("Detect CPU architecture"), workflow)
         assertTrue(workflow.contains("upload-artifact"), workflow)
         assertTrue(workflow.contains("download-artifact"), workflow)
         assertTrue(workflow.contains("scripts/generate-release-metadata.sh"), workflow)
         assertTrue(workflow.contains("release-metadata/latest.json"), workflow)
         assertTrue(workflow.contains("release-metadata/update.json"), workflow)
         assertTrue(workflow.contains("release-metadata/checksums.txt"), workflow)
+        assertTrue(workflow.contains("update_ext: zip"), workflow)
+        assertTrue(workflow.contains("update_ext: tar.gz"), workflow)
     }
 
     private fun sha256(path: Path): String {

--- a/src/test/kotlin/io/github/cdsap/daemonitor/docs/LinuxUpdateDistributionDocTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/docs/LinuxUpdateDistributionDocTest.kt
@@ -13,7 +13,7 @@ class LinuxUpdateDistributionDocTest {
         listOf(
             "direct `.deb` asset on GitHub Releases",
             "signed apt repository",
-            "must not try to self-install updates on Linux",
+            "must not try to self-install updates on Linux installations owned by the system package",
             "If the current install came from the apt repository",
             "If the current install came from a downloaded `.deb`",
             "Package name: `daemonitor`",

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
@@ -137,8 +137,12 @@ class SettingsScreenUiTest {
         val candidate = UpdateCandidate(
             version = "1.0.3",
             releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-macos.dmg",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+            assetName = "Daemonitor-1.0.3-macos-arm64.zip",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos-arm64.zip",
+            platform = io.github.cdsap.daemonitor.update.DesktopPlatform.MACOS,
+            architecture = io.github.cdsap.daemonitor.update.CpuArchitecture.ARM64,
+            role = io.github.cdsap.daemonitor.update.UpdateArtifactRole.UpdatePackage,
+            installMode = io.github.cdsap.daemonitor.update.UpdateInstallMode.Automatic,
         )
         setContent {
             WatcherTheme {
@@ -150,9 +154,49 @@ class SettingsScreenUiTest {
             }
         }
 
-        onNodeWithText("Download and open").performClick()
+        onNodeWithText("Download Update").performClick()
 
         assertEquals(candidate, opened)
+    }
+
+    @Test
+    fun `ready automatic update renders restart action`() = runComposeUiTest {
+        var restarted = 0
+        val candidate = UpdateCandidate(
+            version = "1.0.7",
+            releaseUrl = "https://example.com/release",
+            assetName = "Daemonitor-1.0.7-macos-arm64.zip",
+            downloadUrl = "https://example.com/Daemonitor-1.0.7-macos-arm64.zip",
+            platform = io.github.cdsap.daemonitor.update.DesktopPlatform.MACOS,
+            architecture = io.github.cdsap.daemonitor.update.CpuArchitecture.ARM64,
+            role = io.github.cdsap.daemonitor.update.UpdateArtifactRole.UpdatePackage,
+            installMode = io.github.cdsap.daemonitor.update.UpdateInstallMode.Automatic,
+        )
+        val staged = io.github.cdsap.daemonitor.update.StagedUpdate(
+            candidate = candidate,
+            artifactPath = java.nio.file.Path.of("/tmp/artifact.zip"),
+            payloadPath = java.nio.file.Path.of("/tmp/Daemonitor.app"),
+            installation = io.github.cdsap.daemonitor.update.InstallationInfo(
+                platform = io.github.cdsap.daemonitor.update.DesktopPlatform.MACOS,
+                architecture = io.github.cdsap.daemonitor.update.CpuArchitecture.ARM64,
+                kind = io.github.cdsap.daemonitor.update.InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = java.nio.file.Path.of("/Applications/Daemonitor.app"),
+                relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+            ),
+        )
+        setContent {
+            WatcherTheme {
+                SettingsScreen(
+                    SettingsUiState(updateState = UpdateUiState.ReadyToInstall(candidate, staged)),
+                    onRetentionDays = {},
+                    onRestartAndUpdate = { restarted += 1 },
+                )
+            }
+        }
+
+        onNodeWithText("Daemonitor 1.0.7 is ready to install.").assertExists()
+        onNodeWithText("Restart and Update").performClick()
+        assertEquals(1, restarted)
     }
 
     @Test
@@ -160,8 +204,8 @@ class SettingsScreenUiTest {
         val candidate = UpdateCandidate(
             version = "1.0.3",
             releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-macos.dmg",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+            assetName = "Daemonitor-1.0.3-macos-arm64.zip",
+            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos-arm64.zip",
         )
         setContent {
             WatcherTheme {
@@ -172,6 +216,6 @@ class SettingsScreenUiTest {
             }
         }
 
-        onNodeWithText("Downloading Daemonitor-1.0.3-macos.dmg: 42%.").assertExists()
+        onNodeWithText("Downloading Daemonitor-1.0.3-macos-arm64.zip: 42%.").assertExists()
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -2,9 +2,18 @@ package io.github.cdsap.daemonitor.ui.settings
 
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.update.StagedUpdate
+import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCandidate
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstallMode
 import io.github.cdsap.daemonitor.update.UpdateInstaller
+import io.github.cdsap.daemonitor.update.CpuArchitecture
+import io.github.cdsap.daemonitor.update.DesktopPlatform
+import io.github.cdsap.daemonitor.update.InstallationInfo
+import io.github.cdsap.daemonitor.update.InstallationKind
+import io.github.cdsap.daemonitor.update.UpdateArtifactRole
+import java.nio.file.Path
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -74,11 +83,10 @@ class SettingsViewModelTest {
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `checking for updates exposes available update state`() = runTest {
-        val candidate = UpdateCandidate(
-            version = "1.0.3",
-            releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-macos.dmg",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
+        val candidate = candidate(
+            assetName = "Daemonitor-1.0.3-macos-arm64.zip",
+            installMode = UpdateInstallMode.Automatic,
+            role = UpdateArtifactRole.UpdatePackage,
         )
         val vm = updateViewModel(
             result = UpdateCheckResult.Available(candidate),
@@ -94,12 +102,7 @@ class SettingsViewModelTest {
 
     @Test
     fun `update notification count is only set for available updates`() {
-        val candidate = UpdateCandidate(
-            version = "1.0.3",
-            releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-macos.dmg",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-macos.dmg",
-        )
+        val candidate = candidate("Daemonitor-1.0.3-macos-arm64.zip")
 
         assertEquals(0, SettingsUiState().updateNotificationCount)
         assertEquals(0, SettingsUiState(updateState = UpdateUiState.Checking).updateNotificationCount)
@@ -110,18 +113,30 @@ class SettingsViewModelTest {
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
-    fun `opening an available update delegates to installer`() = runTest {
-        val opened = mutableListOf<UpdateCandidate>()
-        val candidate = UpdateCandidate(
-            version = "1.0.3",
-            releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-linux.deb",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-linux.deb",
+    fun `opening an available update stages automatic packages`() = runTest {
+        val prepared = mutableListOf<UpdateCandidate>()
+        val candidate = candidate(
+            assetName = "Daemonitor-1.0.3-macos-arm64.zip",
+            installMode = UpdateInstallMode.Automatic,
+            role = UpdateArtifactRole.UpdatePackage,
+        )
+        val staged = StagedUpdate(
+            candidate = candidate,
+            artifactPath = Path.of("/tmp/artifact.zip"),
+            payloadPath = Path.of("/tmp/Daemonitor.app"),
+            installation = InstallationInfo(
+                platform = DesktopPlatform.MACOS,
+                architecture = CpuArchitecture.ARM64,
+                kind = InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = Path.of("/Applications/Daemonitor.app"),
+                relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+            ),
         )
         val vm = SettingsViewModel(
             updateInstaller = UpdateInstaller { update, progress ->
                 progress(0.5)
-                opened += update
+                prepared += update
+                staged
             },
             scope = this,
         )
@@ -129,19 +144,49 @@ class SettingsViewModelTest {
         vm.openUpdate(candidate)
         advanceUntilIdle()
 
-        assertEquals(listOf(candidate), opened)
-        assertEquals(UpdateUiState.ReadyToInstall(candidate), vm.state.value.updateState)
+        assertEquals(listOf(candidate), prepared)
+        assertEquals(UpdateUiState.ReadyToInstall(candidate, staged), vm.state.value.updateState)
+    }
+
+    @Test
+    @OptIn(ExperimentalCoroutinesApi::class)
+    fun `restart and update applies staged package then exits`() = runTest {
+        val applied = mutableListOf<StagedUpdate>()
+        var exited = 0
+        val candidate = candidate(
+            assetName = "Daemonitor-1.0.3-macos-arm64.zip",
+            installMode = UpdateInstallMode.Automatic,
+            role = UpdateArtifactRole.UpdatePackage,
+        )
+        val staged = StagedUpdate(
+            candidate = candidate,
+            artifactPath = Path.of("/tmp/artifact.zip"),
+            payloadPath = Path.of("/tmp/Daemonitor.app"),
+            installation = InstallationInfo(
+                platform = DesktopPlatform.MACOS,
+                architecture = CpuArchitecture.ARM64,
+                kind = InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = Path.of("/Applications/Daemonitor.app"),
+                relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+            ),
+        )
+        val vm = SettingsViewModel(
+            initial = SettingsUiState(updateState = UpdateUiState.ReadyToInstall(candidate, staged)),
+            updateApplier = UpdateApplier { applied += it },
+            onExitForUpdate = { exited += 1 },
+            scope = this,
+        )
+
+        vm.restartAndUpdate()
+
+        assertEquals(listOf(staged), applied)
+        assertEquals(1, exited)
     }
 
     @Test
     @OptIn(ExperimentalCoroutinesApi::class)
     fun `installer failures are surfaced in update state`() = runTest {
-        val candidate = UpdateCandidate(
-            version = "1.0.3",
-            releaseUrl = "https://example.com/release",
-            assetName = "Daemonitor-1.0.3-windows.msi",
-            downloadUrl = "https://example.com/Daemonitor-1.0.3-windows.msi",
-        )
+        val candidate = candidate("Daemonitor-1.0.3-windows-x64.msi")
         val vm = SettingsViewModel(
             updateInstaller = UpdateInstaller { _, _ -> error("No desktop") },
             scope = this,
@@ -150,7 +195,10 @@ class SettingsViewModelTest {
         vm.openUpdate(candidate)
         advanceUntilIdle()
 
-        assertEquals(UpdateUiState.Failed("No desktop"), vm.state.value.updateState)
+        assertEquals(
+            UpdateUiState.Failed("No desktop", candidate.releaseUrl),
+            vm.state.value.updateState,
+        )
     }
 
     private fun updateViewModel(
@@ -158,7 +206,22 @@ class SettingsViewModelTest {
         scope: TestScope,
     ): SettingsViewModel = SettingsViewModel(
         updateChecker = { result },
-        updateInstaller = UpdateInstaller { _, _ -> },
+        updateInstaller = UpdateInstaller { _, _ -> null },
         scope = scope,
+    )
+
+    private fun candidate(
+        assetName: String,
+        installMode: UpdateInstallMode = UpdateInstallMode.Manual,
+        role: UpdateArtifactRole = UpdateArtifactRole.Installer,
+    ): UpdateCandidate = UpdateCandidate(
+        version = "1.0.3",
+        releaseUrl = "https://example.com/release",
+        assetName = assetName,
+        downloadUrl = "https://example.com/$assetName",
+        platform = DesktopPlatform.MACOS,
+        architecture = CpuArchitecture.ARM64,
+        role = role,
+        installMode = installMode,
     )
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/CpuArchitectureTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/CpuArchitectureTest.kt
@@ -1,0 +1,16 @@
+package io.github.cdsap.daemonitor.update
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class CpuArchitectureTest {
+
+    @Test
+    fun `maps common jvm arch names`() {
+        assertEquals(CpuArchitecture.ARM64, CpuArchitecture.from("aarch64"))
+        assertEquals(CpuArchitecture.ARM64, CpuArchitecture.from("arm64"))
+        assertEquals(CpuArchitecture.X64, CpuArchitecture.from("x86_64"))
+        assertEquals(CpuArchitecture.X64, CpuArchitecture.from("amd64"))
+        assertEquals(CpuArchitecture.UNKNOWN, CpuArchitecture.from("ppc64"))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatformTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopPlatformTest.kt
@@ -6,10 +6,20 @@ import kotlin.test.assertEquals
 class DesktopPlatformTest {
 
     @Test
-    fun `maps common os names to release asset suffixes`() {
+    fun `maps common os names to platforms`() {
         assertEquals(DesktopPlatform.MACOS, DesktopPlatform.current("Mac OS X"))
         assertEquals(DesktopPlatform.WINDOWS, DesktopPlatform.current("Windows 11"))
         assertEquals(DesktopPlatform.LINUX, DesktopPlatform.current("Linux"))
         assertEquals(DesktopPlatform.UNKNOWN, DesktopPlatform.current("Solaris"))
+    }
+
+    @Test
+    fun `exposes installer and update package extensions`() {
+        assertEquals("dmg", DesktopPlatform.MACOS.installerExtension)
+        assertEquals("zip", DesktopPlatform.MACOS.updatePackageExtension)
+        assertEquals("msi", DesktopPlatform.WINDOWS.installerExtension)
+        assertEquals("zip", DesktopPlatform.WINDOWS.updatePackageExtension)
+        assertEquals("deb", DesktopPlatform.LINUX.installerExtension)
+        assertEquals("tar.gz", DesktopPlatform.LINUX.updatePackageExtension)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopUpdateInstallerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/DesktopUpdateInstallerTest.kt
@@ -5,26 +5,74 @@ import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.MessageDigest
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class DesktopUpdateInstallerTest {
 
     @Test
-    fun `downloads update and opens local installer path`(@TempDir tmp: Path) = runTest {
+    fun `downloads update package and stages payload without opening`(@TempDir tmp: Path) = runTest {
         val opened = mutableListOf<Path>()
         val progress = mutableListOf<Double?>()
         val candidate = UpdateCandidate(
+            version = "1.0.7",
+            releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.7",
+            assetName = "Daemonitor-1.0.7-macos-arm64.zip",
+            downloadUrl = "https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-arm64.zip",
+            sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
+            sizeBytes = 128,
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            role = UpdateArtifactRole.UpdatePackage,
+            installMode = UpdateInstallMode.Automatic,
+        )
+        val zip = tmp.resolve("input.zip").also { writeMacAppZip(it) }
+        val installer = DesktopUpdateInstaller(
+            updateDirectory = tmp.resolve("updates"),
+            installation = macInstall(),
+            opener = { opened.add(it) },
+            downloader = { update, directory, onProgress ->
+                onProgress(0.5)
+                Files.createDirectories(directory)
+                directory.resolve(update.assetName).also { path ->
+                    Files.copy(zip, path)
+                }
+            },
+        )
+
+        val staged = installer.prepare(candidate) { progress.add(it) }
+
+        assertEquals(listOf<Double?>(0.5), progress)
+        assertTrue(opened.isEmpty())
+        assertNotNull(staged)
+        assertEquals("Daemonitor.app", staged.payloadPath.fileName.toString())
+        assertTrue(Files.isDirectory(staged.payloadPath))
+    }
+
+    @Test
+    fun `manual mode downloads and opens local installer path`(@TempDir tmp: Path) = runTest {
+        val opened = mutableListOf<Path>()
+        val candidate = UpdateCandidate(
             version = "1.0.4",
-            releaseUrl = "https://example.com/release",
+            releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.4",
             assetName = "Daemonitor-1.0.4-macos.dmg",
-            downloadUrl = "https://example.com/Daemonitor-1.0.4-macos.dmg",
+            downloadUrl = "https://github.com/cdsap/daemonitor/releases/download/v1.0.4/Daemonitor-1.0.4-macos.dmg",
             sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
             sizeBytes = 128575584,
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            role = UpdateArtifactRole.Installer,
+            installMode = UpdateInstallMode.Manual,
         )
         val installer = DesktopUpdateInstaller(
             updateDirectory = tmp,
+            installation = macInstall(),
             opener = { opened.add(it) },
             downloader = { update, directory, onProgress ->
                 onProgress(0.5)
@@ -34,11 +82,35 @@ class DesktopUpdateInstallerTest {
             },
         )
 
-        installer.open(candidate) { progress.add(it) }
+        val staged = installer.prepare(candidate) {}
 
-        assertEquals(listOf<Double?>(0.5), progress)
+        assertNull(staged)
         assertEquals(listOf(tmp.resolve("Daemonitor-1.0.4-macos.dmg")), opened)
-        assertTrue(Files.exists(opened.single()))
+    }
+
+    @Test
+    fun `rejects architecture mismatches before download`(@TempDir tmp: Path) = runTest {
+        val candidate = UpdateCandidate(
+            version = "1.0.7",
+            releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.7",
+            assetName = "Daemonitor-1.0.7-macos-x64.zip",
+            downloadUrl = "https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-x64.zip",
+            sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.X64,
+            role = UpdateArtifactRole.UpdatePackage,
+            installMode = UpdateInstallMode.Automatic,
+        )
+        val installer = DesktopUpdateInstaller(
+            updateDirectory = tmp,
+            installation = macInstall(),
+            downloader = { _, _, _ -> error("should not download") },
+        )
+
+        val error = assertFailsWith<IllegalArgumentException> {
+            installer.prepare(candidate) {}
+        }
+        assertTrue(error.message!!.contains("architecture"))
     }
 
     @Test
@@ -52,5 +124,66 @@ class DesktopUpdateInstallerTest {
                 "9c0d294c05fc1d88d698034609bb81c0c69196327594e4c69d2915c80fd9850c",
             ),
         )
+    }
+
+    @Test
+    fun `apply helper is launched for staged automatic updates`(@TempDir tmp: Path) {
+        val started = mutableListOf<List<String>>()
+        val app = tmp.resolve("Daemonitor.app").also { Files.createDirectories(it) }
+        val payload = tmp.resolve("staged/Daemonitor.app").also { Files.createDirectories(it) }
+        val artifact = tmp.resolve("Daemonitor-1.0.7-macos-arm64.zip").also { Files.writeString(it, "zip") }
+        val staged = StagedUpdate(
+            candidate = UpdateCandidate(
+                version = "1.0.7",
+                releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.7",
+                assetName = "Daemonitor-1.0.7-macos-arm64.zip",
+                downloadUrl = "https://github.com/cdsap/daemonitor/releases/download/v1.0.7/Daemonitor-1.0.7-macos-arm64.zip",
+                platform = DesktopPlatform.MACOS,
+                architecture = CpuArchitecture.ARM64,
+                role = UpdateArtifactRole.UpdatePackage,
+                installMode = UpdateInstallMode.Automatic,
+            ),
+            artifactPath = artifact,
+            payloadPath = payload,
+            installation = InstallationInfo(
+                platform = DesktopPlatform.MACOS,
+                architecture = CpuArchitecture.ARM64,
+                kind = InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = app,
+                relaunchCommand = listOf("/usr/bin/open", "-n", app.toString()),
+            ),
+        )
+
+        DesktopUpdateApplier(
+            processId = 4242,
+            processStarter = { command, _ -> started += command },
+        ).applyAfterExit(staged)
+
+        assertEquals(1, started.size)
+        assertEquals("/bin/bash", started.single().first())
+        assertTrue(Files.exists(tmp.resolve("apply-update.sh")))
+        val script = Files.readString(tmp.resolve("apply-update.sh"))
+        assertTrue(script.contains("pid=4242"))
+        assertTrue(script.contains(app.toString()))
+    }
+
+    private fun macInstall(): InstallationInfo = InstallationInfo(
+        platform = DesktopPlatform.MACOS,
+        architecture = CpuArchitecture.ARM64,
+        kind = InstallationKind.MACOS_APP_BUNDLE,
+        installRoot = Path.of("/Applications/Daemonitor.app"),
+        relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+    )
+
+    private fun writeMacAppZip(target: Path) {
+        ZipOutputStream(Files.newOutputStream(target)).use { zip ->
+            zip.putNextEntry(ZipEntry("Daemonitor.app/"))
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("Daemonitor.app/Contents/"))
+            zip.closeEntry()
+            zip.putNextEntry(ZipEntry("Daemonitor.app/Contents/Info.plist"))
+            zip.write("plist".toByteArray())
+            zip.closeEntry()
+        }
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/InstallationLocatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/InstallationLocatorTest.kt
@@ -1,0 +1,71 @@
+package io.github.cdsap.daemonitor.update
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InstallationLocatorTest {
+
+    @Test
+    fun `detects macOS app bundle installs`() {
+        val info = InstallationLocator.current(
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
+            javaHome = "/unused",
+            classpath = "unused",
+        )
+
+        assertEquals(InstallationKind.MACOS_APP_BUNDLE, info.kind)
+        assertEquals(Path.of("/Applications/Daemonitor.app"), info.installRoot)
+        assertTrue(info.supportsAutomaticUpdate)
+        assertEquals(listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"), info.relaunchCommand)
+    }
+
+    @Test
+    fun `detects windows app directory installs`() {
+        val info = InstallationLocator.current(
+            platform = DesktopPlatform.WINDOWS,
+            architecture = CpuArchitecture.X64,
+            executable = "C:/Users/demo/AppData/Local/Daemonitor/Daemonitor.exe",
+            javaHome = "C:/unused",
+            classpath = "unused",
+        )
+
+        assertEquals(InstallationKind.WINDOWS_APP_DIR, info.kind)
+        assertEquals(Path.of("C:/Users/demo/AppData/Local/Daemonitor"), info.installRoot)
+        assertTrue(info.supportsAutomaticUpdate)
+    }
+
+    @Test
+    fun `marks linux package managed installs as manual only`() {
+        val info = InstallationLocator.current(
+            platform = DesktopPlatform.LINUX,
+            architecture = CpuArchitecture.X64,
+            executable = "/usr/lib/daemonitor/bin/Daemonitor",
+            javaHome = "/unused",
+            classpath = "unused",
+            packageManagedProbe = { true },
+        )
+
+        assertEquals(InstallationKind.LINUX_PACKAGE_MANAGED, info.kind)
+        assertFalse(info.supportsAutomaticUpdate)
+        assertTrue(info.manualUpdateReason!!.contains("package manager"))
+    }
+
+    @Test
+    fun `marks java classpath launches as development`() {
+        val info = InstallationLocator.current(
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            executable = "/opt/homebrew/opt/openjdk/bin/java",
+            javaHome = "/opt/homebrew/opt/openjdk",
+            classpath = "build/classes",
+        )
+
+        assertEquals(InstallationKind.DEVELOPMENT, info.kind)
+        assertFalse(info.supportsAutomaticUpdate)
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateMetadataJsonParserTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateMetadataJsonParserTest.kt
@@ -12,15 +12,17 @@ class ReleaseUpdateMetadataJsonParserTest {
         val metadata = ReleaseUpdateMetadataJsonParser.parse(
             """
             {
-              "schemaVersion": 1,
+              "schemaVersion": 2,
               "name": "Daemonitor",
               "version": "1.0.4",
               "tag": "v1.0.4",
               "assets": [
                 {
                   "platform": "macos",
-                  "fileName": "Daemonitor-1.0.4-macos.dmg",
-                  "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.4/Daemonitor-1.0.4-macos.dmg",
+                  "arch": "arm64",
+                  "role": "update",
+                  "fileName": "Daemonitor-1.0.4-macos-arm64.zip",
+                  "url": "https://github.com/cdsap/daemonitor/releases/download/v1.0.4/Daemonitor-1.0.4-macos-arm64.zip",
                   "sha256": "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
                   "size": 128575584
                 }
@@ -30,9 +32,12 @@ class ReleaseUpdateMetadataJsonParserTest {
         )
 
         requireNotNull(metadata)
+        assertEquals(2, metadata.schemaVersion)
         assertEquals("1.0.4", metadata.version)
         assertEquals("v1.0.4", metadata.tag)
-        assertEquals("Daemonitor-1.0.4-macos.dmg", metadata.assets.single().fileName)
+        assertEquals("Daemonitor-1.0.4-macos-arm64.zip", metadata.assets.single().fileName)
+        assertEquals("arm64", metadata.assets.single().arch)
+        assertEquals("update", metadata.assets.single().role)
         assertEquals("24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1", metadata.assets.single().sha256)
         assertEquals(128575584, metadata.assets.single().sizeBytes)
     }
@@ -43,17 +48,29 @@ class ReleaseUpdateMetadataJsonParserTest {
     }
 
     @Test
-    fun `selects metadata asset for current platform`() {
+    fun `selects metadata update package for automatic installs`() {
         val metadata = ReleaseUpdateMetadata(
+            schemaVersion = 2,
             version = "1.0.4",
             tag = "v1.0.4",
             assets = listOf(
                 ReleaseUpdateAsset(
                     platform = "macos",
-                    fileName = "Daemonitor-1.0.4-macos.dmg",
-                    url = "https://example.com/Daemonitor-1.0.4-macos.dmg",
+                    fileName = "Daemonitor-1.0.4-macos-arm64.dmg",
+                    url = "https://example.com/Daemonitor-1.0.4-macos-arm64.dmg",
                     sha256 = "24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1",
                     sizeBytes = 128575584,
+                    arch = "arm64",
+                    role = "installer",
+                ),
+                ReleaseUpdateAsset(
+                    platform = "macos",
+                    fileName = "Daemonitor-1.0.4-macos-arm64.zip",
+                    url = "https://example.com/Daemonitor-1.0.4-macos-arm64.zip",
+                    sha256 = "34fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c2",
+                    sizeBytes = 120000000,
+                    arch = "arm64",
+                    role = "update",
                 ),
             ),
         )
@@ -63,12 +80,21 @@ class ReleaseUpdateMetadataJsonParserTest {
             releaseUrl = "https://github.com/cdsap/daemonitor/releases/tag/v1.0.4",
             currentVersion = "1.0.3",
             platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            installation = InstallationInfo(
+                platform = DesktopPlatform.MACOS,
+                architecture = CpuArchitecture.ARM64,
+                kind = InstallationKind.MACOS_APP_BUNDLE,
+                installRoot = java.nio.file.Path.of("/Applications/Daemonitor.app"),
+                relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+            ),
         )
 
         val available = assertIs<UpdateCheckResult.Available>(result)
         assertEquals("1.0.4", available.candidate.version)
-        assertEquals("Daemonitor-1.0.4-macos.dmg", available.candidate.assetName)
-        assertEquals("24fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c1", available.candidate.sha256)
-        assertEquals(128575584, available.candidate.sizeBytes)
+        assertEquals("Daemonitor-1.0.4-macos-arm64.zip", available.candidate.assetName)
+        assertEquals(UpdateInstallMode.Automatic, available.candidate.installMode)
+        assertEquals("34fa35b9fcbe9e069c677b045b7509a01d5376b46cdb8aa655d61069575564c2", available.candidate.sha256)
+        assertEquals(120000000, available.candidate.sizeBytes)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateSelectorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/update/ReleaseUpdateSelectorTest.kt
@@ -3,6 +3,70 @@ package io.github.cdsap.daemonitor.update
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class UpdateArtifactMatcherTest {
+
+    @Test
+    fun `prefers arch specific update package when automatic updates are supported`() {
+        val selected = UpdateArtifactMatcher.selectAsset(
+            assets = listOf(
+                NamedReleaseAsset("Daemonitor-1.0.7-macos.dmg", "https://example.com/dmg"),
+                NamedReleaseAsset("Daemonitor-1.0.7-macos-arm64.dmg", "https://example.com/dmg-arm"),
+                NamedReleaseAsset("Daemonitor-1.0.7-macos-x64.zip", "https://example.com/zip-x64"),
+                NamedReleaseAsset("Daemonitor-1.0.7-macos-arm64.zip", "https://example.com/zip-arm"),
+            ),
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            preferAutomatic = true,
+        )
+
+        assertEquals("Daemonitor-1.0.7-macos-arm64.zip", selected?.fileName)
+    }
+
+    @Test
+    fun `prefers installer when automatic updates are unavailable`() {
+        val selected = UpdateArtifactMatcher.selectAsset(
+            assets = listOf(
+                NamedReleaseAsset("Daemonitor-1.0.7-linux-x64.tar.gz", "https://example.com/tar"),
+                NamedReleaseAsset("Daemonitor-1.0.7-linux-x64.deb", "https://example.com/deb"),
+            ),
+            platform = DesktopPlatform.LINUX,
+            architecture = CpuArchitecture.X64,
+            preferAutomatic = false,
+        )
+
+        assertEquals("Daemonitor-1.0.7-linux-x64.deb", selected?.fileName)
+    }
+
+    @Test
+    fun `rejects architecture mismatches`() {
+        assertNull(
+            UpdateArtifactMatcher.selectAsset(
+                assets = listOf(
+                    NamedReleaseAsset("Daemonitor-1.0.7-windows-arm64.zip", "https://example.com/zip"),
+                ),
+                platform = DesktopPlatform.WINDOWS,
+                architecture = CpuArchitecture.X64,
+                preferAutomatic = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `falls back to legacy platform only assets`() {
+        val selected = UpdateArtifactMatcher.selectAsset(
+            assets = listOf(
+                NamedReleaseAsset("Daemonitor-1.0.6-macos.dmg", "https://example.com/dmg"),
+            ),
+            platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            preferAutomatic = false,
+        )
+
+        assertEquals("Daemonitor-1.0.6-macos.dmg", selected?.fileName)
+    }
+}
 
 class ReleaseUpdateSelectorTest {
 
@@ -12,12 +76,15 @@ class ReleaseUpdateSelectorTest {
             release = release("v1.0.3"),
             currentVersion = "1.0.2",
             platform = DesktopPlatform.MACOS,
+            architecture = CpuArchitecture.ARM64,
+            installation = automaticMac(),
         )
 
         val available = assertIs<UpdateCheckResult.Available>(result)
         assertEquals("1.0.3", available.candidate.version)
-        assertEquals("Daemonitor-1.0.3-macos.dmg", available.candidate.assetName)
-        assertEquals("https://example.com/Daemonitor-1.0.3-macos.dmg", available.candidate.downloadUrl)
+        assertEquals("Daemonitor-1.0.3-macos-arm64.zip", available.candidate.assetName)
+        assertEquals(UpdateInstallMode.Automatic, available.candidate.installMode)
+        assertEquals(UpdateArtifactRole.UpdatePackage, available.candidate.role)
     }
 
     @Test
@@ -26,6 +93,8 @@ class ReleaseUpdateSelectorTest {
             release = release("v1.0.2"),
             currentVersion = "1.0.2",
             platform = DesktopPlatform.WINDOWS,
+            architecture = CpuArchitecture.X64,
+            installation = manualWindows(),
         )
 
         assertEquals(UpdateCheckResult.UpToDate("1.0.2"), result)
@@ -37,6 +106,8 @@ class ReleaseUpdateSelectorTest {
             release = release("v1.0.3"),
             currentVersion = "1.0.2",
             platform = DesktopPlatform.LINUX,
+            architecture = CpuArchitecture.X64,
+            installation = packageManagedLinux(),
         )
 
         assertEquals(
@@ -45,12 +116,74 @@ class ReleaseUpdateSelectorTest {
         )
     }
 
+    @Test
+    fun `uses manual installer when automatic updates are unsupported`() {
+        val result = ReleaseUpdateSelector.select(
+            release = GitHubRelease(
+                version = "v1.0.7",
+                releaseUrl = "https://example.com/release",
+                assets = listOf(
+                    GitHubReleaseAsset(
+                        "Daemonitor-1.0.7-linux-x64.tar.gz",
+                        "https://example.com/Daemonitor-1.0.7-linux-x64.tar.gz",
+                    ),
+                    GitHubReleaseAsset(
+                        "Daemonitor-1.0.7-linux-x64.deb",
+                        "https://example.com/Daemonitor-1.0.7-linux-x64.deb",
+                    ),
+                ),
+            ),
+            currentVersion = "1.0.6",
+            platform = DesktopPlatform.LINUX,
+            architecture = CpuArchitecture.X64,
+            installation = packageManagedLinux(),
+        )
+
+        val available = assertIs<UpdateCheckResult.Available>(result)
+        assertEquals("Daemonitor-1.0.7-linux-x64.deb", available.candidate.assetName)
+        assertEquals(UpdateInstallMode.Manual, available.candidate.installMode)
+    }
+
     private fun release(version: String): GitHubRelease = GitHubRelease(
         version = version,
         releaseUrl = "https://example.com/release",
         assets = listOf(
-            GitHubReleaseAsset("Daemonitor-${version.removePrefix("v")}-macos.dmg", "https://example.com/Daemonitor-${version.removePrefix("v")}-macos.dmg"),
-            GitHubReleaseAsset("Daemonitor-${version.removePrefix("v")}-windows.msi", "https://example.com/Daemonitor-${version.removePrefix("v")}-windows.msi"),
+            GitHubReleaseAsset(
+                "Daemonitor-${version.removePrefix("v")}-macos-arm64.zip",
+                "https://example.com/Daemonitor-${version.removePrefix("v")}-macos-arm64.zip",
+            ),
+            GitHubReleaseAsset(
+                "Daemonitor-${version.removePrefix("v")}-macos-arm64.dmg",
+                "https://example.com/Daemonitor-${version.removePrefix("v")}-macos-arm64.dmg",
+            ),
+            GitHubReleaseAsset(
+                "Daemonitor-${version.removePrefix("v")}-windows-x64.msi",
+                "https://example.com/Daemonitor-${version.removePrefix("v")}-windows-x64.msi",
+            ),
         ),
+    )
+
+    private fun automaticMac(): InstallationInfo = InstallationInfo(
+        platform = DesktopPlatform.MACOS,
+        architecture = CpuArchitecture.ARM64,
+        kind = InstallationKind.MACOS_APP_BUNDLE,
+        installRoot = java.nio.file.Path.of("/Applications/Daemonitor.app"),
+        relaunchCommand = listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"),
+    )
+
+    private fun manualWindows(): InstallationInfo = InstallationInfo(
+        platform = DesktopPlatform.WINDOWS,
+        architecture = CpuArchitecture.X64,
+        kind = InstallationKind.DEVELOPMENT,
+        installRoot = null,
+        relaunchCommand = emptyList(),
+    )
+
+    private fun packageManagedLinux(): InstallationInfo = InstallationInfo(
+        platform = DesktopPlatform.LINUX,
+        architecture = CpuArchitecture.X64,
+        kind = InstallationKind.LINUX_PACKAGE_MANAGED,
+        installRoot = java.nio.file.Path.of("/usr/lib/daemonitor"),
+        relaunchCommand = listOf("/usr/lib/daemonitor/bin/Daemonitor"),
     )
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#71: Add cross-platform in-app self-update and Restart to Update flow

Fixes #71

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`