### PR TITLE
fix: refactor mode switcher launch commands to shared helper

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppLaunchCommand.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppLaunchCommand.kt
@@ -1,0 +1,66 @@
+package io.github.cdsap.daemonitor
+
+import java.io.File
+
+internal object AppLaunchCommand {
+    private const val ENTRY_POINT = "io.github.cdsap.daemonitor.Daemonitor"
+
+    fun start(command: List<String>): Process =
+        ProcessBuilder(command)
+            .directory(File(System.getProperty("user.dir")))
+            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .start()
+
+    fun currentProcess(): CurrentProcess {
+        val info = ProcessHandle.current().info()
+        return CurrentProcess(
+            executable = info.command().orElse(null),
+            javaHome = System.getProperty("java.home"),
+            classpath = System.getProperty("java.class.path"),
+        )
+    }
+
+    fun isJavaExecutable(executable: String): Boolean {
+        val name = executable.substringAfterLast('/').substringAfterLast('\\').lowercase()
+        return name == "java" || name == "java.exe"
+    }
+
+    fun isMacOs(osName: String): Boolean = osName.lowercase().contains("mac")
+
+    fun macAppBundlePath(executable: String): String? {
+        val marker = ".app/Contents/MacOS/"
+        val index = executable.indexOf(marker)
+        if (index < 0) return null
+        return executable.substring(0, index + ".app".length)
+    }
+
+    fun javaClasspathLaunch(
+        javaHome: String,
+        classpath: String,
+        osName: String,
+        extraArgs: List<String> = emptyList(),
+    ): List<String> =
+        listOf(
+            javaExecutablePath(javaHome, javaExecutableName(osName)),
+            "-cp",
+            classpath,
+            ENTRY_POINT,
+        ) + extraArgs
+
+    private fun javaExecutableName(osName: String): String =
+        if (osName.lowercase().contains("windows")) "java.exe" else "java"
+
+    private fun javaExecutablePath(javaHome: String, executableName: String): String =
+        if (javaHome.contains('\\')) {
+            "${javaHome.trimEnd('\\')}\\bin\\$executableName"
+        } else {
+            "${javaHome.trimEnd('/')}/bin/$executableName"
+        }
+
+    data class CurrentProcess(
+        val executable: String?,
+        val javaHome: String,
+        val classpath: String,
+    )
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
@@ -1,16 +1,7 @@
 package io.github.cdsap.daemonitor
 
-import java.io.File
-
 internal object DesktopModeSwitcher {
-    fun launch(): Process {
-        val command = currentProcessCommand()
-        val builder = ProcessBuilder(command)
-            .directory(File(System.getProperty("user.dir")))
-            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-        return builder.start()
-    }
+    fun launch(): Process = AppLaunchCommand.start(currentProcessCommand())
 
     internal fun commandForCurrentProcess(
         executable: String?,
@@ -18,51 +9,24 @@ internal object DesktopModeSwitcher {
         classpath: String,
         osName: String = System.getProperty("os.name"),
     ): List<String> {
-        if (executable != null && !executable.isJavaExecutable()) {
-            if (osName.isMacOs()) {
-                executable.macAppBundlePath()?.let { return listOf("/usr/bin/open", "-n", it) }
+        if (executable != null && !AppLaunchCommand.isJavaExecutable(executable)) {
+            if (AppLaunchCommand.isMacOs(osName)) {
+                AppLaunchCommand.macAppBundlePath(executable)?.let {
+                    return listOf("/usr/bin/open", "-n", it)
+                }
             }
             return listOf(executable)
         }
 
-        return listOf(
-            javaExecutablePath(javaHome, javaExecutableName(osName)),
-            "-cp",
-            classpath,
-            "io.github.cdsap.daemonitor.Daemonitor",
-        )
+        return AppLaunchCommand.javaClasspathLaunch(javaHome, classpath, osName)
     }
 
     private fun currentProcessCommand(): List<String> {
-        val info = ProcessHandle.current().info()
+        val process = AppLaunchCommand.currentProcess()
         return commandForCurrentProcess(
-            executable = info.command().orElse(null),
-            javaHome = System.getProperty("java.home"),
-            classpath = System.getProperty("java.class.path"),
+            executable = process.executable,
+            javaHome = process.javaHome,
+            classpath = process.classpath,
         )
     }
-
-    private fun String.isJavaExecutable(): Boolean {
-        val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
-        return name == "java" || name == "java.exe"
-    }
-
-    private fun String.macAppBundlePath(): String? {
-        val marker = ".app/Contents/MacOS/"
-        val index = indexOf(marker)
-        if (index < 0) return null
-        return substring(0, index + ".app".length)
-    }
-
-    private fun String.isMacOs(): Boolean = lowercase().contains("mac")
-
-    private fun javaExecutableName(osName: String): String =
-        if (osName.lowercase().contains("windows")) "java.exe" else "java"
-
-    private fun javaExecutablePath(javaHome: String, executableName: String): String =
-        if (javaHome.contains('\\')) {
-            "${javaHome.trimEnd('\\')}\\bin\\$executableName"
-        } else {
-            "${javaHome.trimEnd('/')}/bin/$executableName"
-        }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
@@ -1,16 +1,7 @@
 package io.github.cdsap.daemonitor
 
-import java.io.File
-
 internal object HeadlessModeSwitcher {
-    fun launch(): Process {
-        val command = currentProcessCommand()
-        val builder = ProcessBuilder(command)
-            .directory(File(System.getProperty("user.dir")))
-            .redirectOutput(ProcessBuilder.Redirect.INHERIT)
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
-        return builder.start()
-    }
+    fun launch(): Process = AppLaunchCommand.start(currentProcessCommand())
 
     internal fun commandForCurrentProcess(
         executable: String?,
@@ -18,41 +9,24 @@ internal object HeadlessModeSwitcher {
         classpath: String,
         osName: String = System.getProperty("os.name"),
     ): List<String> {
-        if (executable != null && !executable.isJavaExecutable()) {
+        if (executable != null && !AppLaunchCommand.isJavaExecutable(executable)) {
             return listOf(executable, "--headless")
         }
 
-        val javaExecutable = javaExecutablePath(javaHome, javaExecutableName(osName))
-        return listOf(
-            javaExecutable,
-            "-cp",
-            classpath,
-            "io.github.cdsap.daemonitor.Daemonitor",
-            "--headless",
+        return AppLaunchCommand.javaClasspathLaunch(
+            javaHome = javaHome,
+            classpath = classpath,
+            osName = osName,
+            extraArgs = listOf("--headless"),
         )
     }
 
     private fun currentProcessCommand(): List<String> {
-        val info = ProcessHandle.current().info()
+        val process = AppLaunchCommand.currentProcess()
         return commandForCurrentProcess(
-            executable = info.command().orElse(null),
-            javaHome = System.getProperty("java.home"),
-            classpath = System.getProperty("java.class.path"),
+            executable = process.executable,
+            javaHome = process.javaHome,
+            classpath = process.classpath,
         )
     }
-
-    private fun String.isJavaExecutable(): Boolean {
-        val name = substringAfterLast('/').substringAfterLast('\\').lowercase()
-        return name == "java" || name == "java.exe"
-    }
-
-    private fun javaExecutableName(osName: String): String =
-        if (osName.lowercase().contains("windows")) "java.exe" else "java"
-
-    private fun javaExecutablePath(javaHome: String, executableName: String): String =
-        if (javaHome.contains('\\')) {
-            "${javaHome.trimEnd('\\')}\\bin\\$executableName"
-        } else {
-            "${javaHome.trimEnd('/')}/bin/$executableName"
-        }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcherTest.kt
@@ -47,4 +47,24 @@ class DesktopModeSwitcherTest {
             command,
         )
     }
+
+    @Test
+    fun `source run uses windows java executable name on windows`() {
+        val command = DesktopModeSwitcher.commandForCurrentProcess(
+            executable = "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64\\bin\\java.exe",
+            javaHome = "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64",
+            classpath = "build/classes;kotlin-runtime.jar",
+            osName = "Windows Server 2025",
+        )
+
+        assertEquals(
+            listOf(
+                "C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\21\\x64\\bin\\java.exe",
+                "-cp",
+                "build/classes;kotlin-runtime.jar",
+                "io.github.cdsap.daemonitor.Daemonitor",
+            ),
+            command,
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#80: Refactor mode switcher launch commands to shared helper

Fixes #80

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`