### PR TITLE
fix: public page should mention ikotlin also

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -3,21 +3,21 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Daemonitor — Activity Monitor for Gradle daemons</title>
-  <meta name="description" content="Daemonitor is a local Activity Monitor for Gradle daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
+  <title>Daemonitor — Activity Monitor for Gradle and Kotlin daemons</title>
+  <meta name="description" content="Daemonitor is a local Activity Monitor for Gradle and Kotlin daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
   <meta name="theme-color" content="#28735F" media="(prefers-color-scheme: light)">
   <meta name="theme-color" content="#111413" media="(prefers-color-scheme: dark)">
 
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Daemonitor">
   <meta property="og:url" content="https://cdsap.github.io/daemonitor/">
-  <meta property="og:title" content="Daemonitor — Activity Monitor for Gradle daemons">
-  <meta property="og:description" content="Daemonitor is a local Activity Monitor for Gradle daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
+  <meta property="og:title" content="Daemonitor — Activity Monitor for Gradle and Kotlin daemons">
+  <meta property="og:description" content="Daemonitor is a local Activity Monitor for Gradle and Kotlin daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
   <meta property="og:image" content="https://cdsap.github.io/daemonitor/assets/live-monitor.png">
 
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="Daemonitor — Activity Monitor for Gradle daemons">
-  <meta name="twitter:description" content="Daemonitor is a local Activity Monitor for Gradle daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
+  <meta name="twitter:title" content="Daemonitor — Activity Monitor for Gradle and Kotlin daemons">
+  <meta name="twitter:description" content="Daemonitor is a local Activity Monitor for Gradle and Kotlin daemons. See active builds, CPU and memory usage, build history, and which IDE, terminal, or AI coding agent triggered each build.">
   <meta name="twitter:image" content="https://cdsap.github.io/daemonitor/assets/live-monitor.png">
 
   <link rel="icon" type="image/png" href="assets/favicon.png">
@@ -49,7 +49,7 @@
           <img src="assets/icon-192.png" width="56" height="56" alt="">
           <span>Daemonitor</span>
         </p>
-        <h1 id="hero-heading">Activity Monitor for your Gradle daemons</h1>
+        <h1 id="hero-heading">Activity Monitor for your Gradle and Kotlin daemons</h1>
         <p class="lede">
           See what's building right now, what built recently, and which IDE, terminal,
           or AI coding agent triggered it.

--- a/src/test/kotlin/io/github/cdsap/daemonitor/docs/PublicWebsiteTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/docs/PublicWebsiteTest.kt
@@ -48,13 +48,14 @@ class PublicWebsiteTest {
     @Test
     fun `landing page covers hero features privacy download and metadata`() {
         listOf(
-            "Daemonitor — Activity Monitor for Gradle daemons",
+            "Daemonitor — Activity Monitor for Gradle and Kotlin daemons",
             "meta name=\"description\"",
             "property=\"og:title\"",
             "property=\"og:description\"",
             "property=\"og:image\"",
             "rel=\"icon\"",
-            "Activity Monitor for your Gradle daemons",
+            "Activity Monitor for your Gradle and Kotlin daemons",
+            "local Activity Monitor for Gradle and Kotlin daemons",
             "Download Daemonitor",
             "View on GitHub",
             "macOS · Windows · Linux",


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#82: Public Page should mention iKotlin also

Fixes #82

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `medium`

## Verification

- `./gradlew test`