### PR TITLE
fix: fix linux watcherservicetest background coroutine race

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -17,7 +17,9 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -34,6 +36,7 @@ class WatcherService(
         GitHubReleaseUpdateSource().check(BuildInfo.current.version)
     },
     private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     val liveViewModel = LiveViewModel()
     val historyViewModel = HistoryViewModel()
@@ -58,21 +61,39 @@ class WatcherService(
     )
 
     private var serviceScope: CoroutineScope? = null
+    private var serviceJob: Job? = null
     @Volatile private var mcpHttpServer: DaemonitorMcpHttpServer? = null
 
     fun start(scope: CoroutineScope) {
-        serviceScope = scope
+        serviceJob?.cancel()
+        val job = SupervisorJob(scope.coroutineContext[Job])
+        serviceJob = job
+        val boundScope = CoroutineScope(scope.coroutineContext + job)
+        serviceScope = boundScope
         settingsViewModel.checkForUpdates()
-        if (settingsViewModel.state.value.mcpEnabled) startMcpServer(scope)
+        if (settingsViewModel.state.value.mcpEnabled) startMcpServer(boundScope)
         database.purgeOlderThan(clock(), retentionDays)
         // Load whatever history already exists, then keep it current from the poll loop.
-        scope.launch(Dispatchers.IO) { refreshHistory() }
-        scope.launch(Dispatchers.IO) {
+        boundScope.launch(ioDispatcher) { refreshHistory() }
+        boundScope.launch(ioDispatcher) {
             while (isActive) {
                 pollSafely()
                 delay(Defaults.POLL_INTERVAL)
             }
         }
+    }
+
+    /**
+     * Cancels background poll/history work and waits for it to finish.
+     * Call this before closing [database] so temp-dir cleanup cannot race in-flight SQLite access.
+     */
+    suspend fun stop() {
+        mcpHttpServer?.close()
+        mcpHttpServer = null
+        val job = serviceJob
+        serviceJob = null
+        serviceScope = null
+        job?.cancelAndJoin()
     }
 
     /** User changed the retention window: persist it, purge anything now out of range, and refresh
@@ -81,7 +102,7 @@ class WatcherService(
         retentionDays = days
         saveSettings()
         val scope = serviceScope ?: return
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             database.purgeOlderThan(clock(), days)
             refreshHistory()
         }
@@ -109,7 +130,7 @@ class WatcherService(
             settingsViewModel.setMcpRunning(existing.endpoint)
             return
         }
-        scope.launch(Dispatchers.IO) {
+        scope.launch(ioDispatcher) {
             withContext(uiDispatcher) {
                 settingsViewModel.setMcpRunningState(McpUiState.Starting)
             }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -4,11 +4,13 @@ import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.ui.settings.UpdateUiState
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.Test
@@ -22,11 +24,10 @@ class WatcherServiceTest {
     fun `failed poll records sanitized error and failure timestamp`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
         val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { 100 }) {
+            error("secret command line and log content")
+        }
         try {
-            val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { 100 }) {
-                error("secret command line and log content")
-            }
-
             service.pollSafely()
 
             val error = service.liveViewModel.state.value.pollError
@@ -34,6 +35,7 @@ class WatcherServiceTest {
             assertEquals("IllegalStateException", error?.errorType)
             assertFalse(error.toString().contains("secret"))
         } finally {
+            service.stop()
             database.close()
         }
     }
@@ -42,14 +44,13 @@ class WatcherServiceTest {
     fun `repeated failure replaces the latest failure timestamp`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
         val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        var now = 100L
+        var firstFailure = true
+        val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { now }) {
+            if (firstFailure) throw IllegalArgumentException("first failure")
+            error("second failure")
+        }
         try {
-            var now = 100L
-            var firstFailure = true
-            val service = service(database, tmp, uiDispatcher = uiDispatcher, clock = { now }) {
-                if (firstFailure) throw IllegalArgumentException("first failure")
-                error("second failure")
-            }
-
             service.pollSafely()
             firstFailure = false
             now = 200
@@ -59,6 +60,7 @@ class WatcherServiceTest {
             assertEquals(200, error?.failedAtMs)
             assertEquals("IllegalStateException", error?.errorType)
         } finally {
+            service.stop()
             database.close()
         }
     }
@@ -67,19 +69,19 @@ class WatcherServiceTest {
     fun `successful retry clears the previous failure`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
         val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        var fail = true
+        val service = service(database, tmp, uiDispatcher = uiDispatcher) {
+            if (fail) error("failure")
+            WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
+        }
         try {
-            var fail = true
-            val service = service(database, tmp, uiDispatcher = uiDispatcher) {
-                if (fail) error("failure")
-                WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
-            }
-
             service.pollSafely()
             fail = false
             service.pollSafely()
 
             assertNull(service.liveViewModel.state.value.pollError)
         } finally {
+            service.stop()
             database.close()
         }
     }
@@ -88,27 +90,56 @@ class WatcherServiceTest {
     fun `starting service checks for updates`(@TempDir tmp: Path) = runTest {
         val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
         val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        var updateChecks = 0
+        val service = service(
+            database = database,
+            tmp = tmp,
+            uiDispatcher = uiDispatcher,
+            updateChecker = {
+                updateChecks += 1
+                UpdateCheckResult.UpToDate("1.0.3")
+            },
+        ) {
+            WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
+        }
         try {
-            var updateChecks = 0
-            val service = service(
-                database = database,
-                tmp = tmp,
-                uiDispatcher = uiDispatcher,
-                updateChecker = {
-                    updateChecks += 1
-                    UpdateCheckResult.UpToDate("1.0.3")
-                },
-            ) {
-                WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
-            }
-
             service.start(backgroundScope)
             advanceUntilIdle()
 
             assertEquals(1, updateChecks)
             assertEquals(UpdateUiState.UpToDate("1.0.3"), service.settingsViewModel.state.value.updateState)
         } finally {
+            service.stop()
             database.close()
+        }
+    }
+
+    @Test
+    fun `stop joins background work before database close`(@TempDir tmp: Path) = runTest {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        val uiDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val pollEntered = CompletableDeferred<Unit>()
+        val releasePoll = CompletableDeferred<Unit>()
+        var pollStillRunningAfterStop = false
+        val service = service(database, tmp, uiDispatcher = uiDispatcher) {
+            pollEntered.complete(Unit)
+            releasePoll.await()
+            pollStillRunningAfterStop = true
+            WatcherRuntime.PollResult(emptyList(), emptyList(), buildsChanged = false)
+        }
+        try {
+            service.start(backgroundScope)
+            withTimeout(5_000) { pollEntered.await() }
+
+            withTimeout(5_000) { service.stop() }
+            // Closing must be safe only after stop has joined in-flight IO.
+            database.close()
+
+            assertFalse(pollStillRunningAfterStop)
+        } finally {
+            releasePoll.cancel()
+            runCatching { service.stop() }
+            runCatching { database.close() }
         }
     }
 
@@ -127,5 +158,6 @@ class WatcherServiceTest {
         pollAction = pollAction,
         updateChecker = updateChecker,
         uiDispatcher = uiDispatcher,
+        ioDispatcher = uiDispatcher,
     )
 }


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#84: Fix Linux WatcherServiceTest background coroutine race

Fixes #84

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `medium`

## Verification

- `./gradlew test`