### PR TITLE
fix: refactor mode switcher command construction to a shared launcher he

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppLaunchCommand.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppLaunchCommand.kt
@@ -5,6 +5,11 @@ import java.io.File
 internal object AppLaunchCommand {
     private const val ENTRY_POINT = "io.github.cdsap.daemonitor.Daemonitor"
 
+    data class Options(
+        val extraArgs: List<String> = emptyList(),
+        val reopenMacDesktopBundle: Boolean = false,
+    )
+
     fun start(command: List<String>): Process =
         ProcessBuilder(command)
             .directory(File(System.getProperty("user.dir")))
@@ -21,12 +26,34 @@ internal object AppLaunchCommand {
         )
     }
 
+    fun buildCommand(
+        executable: String?,
+        javaHome: String,
+        classpath: String,
+        osName: String,
+        options: Options,
+    ): List<String> {
+        if (executable != null && !isJavaExecutable(executable)) {
+            if (options.reopenMacDesktopBundle && isMacOs(osName)) {
+                macAppBundlePath(executable)?.let {
+                    return listOf("/usr/bin/open", "-n", it)
+                }
+            }
+            return listOf(executable) + options.extraArgs
+        }
+
+        return listOf(
+            javaExecutablePath(javaHome, osName),
+            "-cp",
+            classpath,
+            ENTRY_POINT,
+        ) + options.extraArgs
+    }
+
     fun isJavaExecutable(executable: String): Boolean {
         val name = executable.substringAfterLast('/').substringAfterLast('\\').lowercase()
         return name == "java" || name == "java.exe"
     }
-
-    fun isMacOs(osName: String): Boolean = osName.lowercase().contains("mac")
 
     fun macAppBundlePath(executable: String): String? {
         val marker = ".app/Contents/MacOS/"
@@ -35,28 +62,19 @@ internal object AppLaunchCommand {
         return executable.substring(0, index + ".app".length)
     }
 
-    fun javaClasspathLaunch(
-        javaHome: String,
-        classpath: String,
-        osName: String,
-        extraArgs: List<String> = emptyList(),
-    ): List<String> =
-        listOf(
-            javaExecutablePath(javaHome, javaExecutableName(osName)),
-            "-cp",
-            classpath,
-            ENTRY_POINT,
-        ) + extraArgs
-
-    private fun javaExecutableName(osName: String): String =
-        if (osName.lowercase().contains("windows")) "java.exe" else "java"
-
-    private fun javaExecutablePath(javaHome: String, executableName: String): String =
-        if (javaHome.contains('\\')) {
+    fun javaExecutablePath(javaHome: String, osName: String): String {
+        val executableName = javaExecutableName(osName)
+        return if (javaHome.contains('\\')) {
             "${javaHome.trimEnd('\\')}\\bin\\$executableName"
         } else {
             "${javaHome.trimEnd('/')}/bin/$executableName"
         }
+    }
+
+    private fun isMacOs(osName: String): Boolean = osName.lowercase().contains("mac")
+
+    private fun javaExecutableName(osName: String): String =
+        if (osName.lowercase().contains("windows")) "java.exe" else "java"
 
     data class CurrentProcess(
         val executable: String?,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DesktopModeSwitcher.kt
@@ -1,6 +1,8 @@
 package io.github.cdsap.daemonitor
 
 internal object DesktopModeSwitcher {
+    private val options = AppLaunchCommand.Options(reopenMacDesktopBundle = true)
+
     fun launch(): Process = AppLaunchCommand.start(currentProcessCommand())
 
     internal fun commandForCurrentProcess(
@@ -8,18 +10,14 @@ internal object DesktopModeSwitcher {
         javaHome: String,
         classpath: String,
         osName: String = System.getProperty("os.name"),
-    ): List<String> {
-        if (executable != null && !AppLaunchCommand.isJavaExecutable(executable)) {
-            if (AppLaunchCommand.isMacOs(osName)) {
-                AppLaunchCommand.macAppBundlePath(executable)?.let {
-                    return listOf("/usr/bin/open", "-n", it)
-                }
-            }
-            return listOf(executable)
-        }
-
-        return AppLaunchCommand.javaClasspathLaunch(javaHome, classpath, osName)
-    }
+    ): List<String> =
+        AppLaunchCommand.buildCommand(
+            executable = executable,
+            javaHome = javaHome,
+            classpath = classpath,
+            osName = osName,
+            options = options,
+        )
 
     private fun currentProcessCommand(): List<String> {
         val process = AppLaunchCommand.currentProcess()

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessModeSwitcher.kt
@@ -1,6 +1,8 @@
 package io.github.cdsap.daemonitor
 
 internal object HeadlessModeSwitcher {
+    private val options = AppLaunchCommand.Options(extraArgs = listOf("--headless"))
+
     fun launch(): Process = AppLaunchCommand.start(currentProcessCommand())
 
     internal fun commandForCurrentProcess(
@@ -8,18 +10,14 @@ internal object HeadlessModeSwitcher {
         javaHome: String,
         classpath: String,
         osName: String = System.getProperty("os.name"),
-    ): List<String> {
-        if (executable != null && !AppLaunchCommand.isJavaExecutable(executable)) {
-            return listOf(executable, "--headless")
-        }
-
-        return AppLaunchCommand.javaClasspathLaunch(
+    ): List<String> =
+        AppLaunchCommand.buildCommand(
+            executable = executable,
             javaHome = javaHome,
             classpath = classpath,
             osName = osName,
-            extraArgs = listOf("--headless"),
+            options = options,
         )
-    }
 
     private fun currentProcessCommand(): List<String> {
         val process = AppLaunchCommand.currentProcess()

--- a/src/test/kotlin/io/github/cdsap/daemonitor/AppLaunchCommandTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/AppLaunchCommandTest.kt
@@ -1,0 +1,67 @@
+package io.github.cdsap.daemonitor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AppLaunchCommandTest {
+    @Test
+    fun `detects java executables across path separators`() {
+        assertTrue(AppLaunchCommand.isJavaExecutable("/opt/jdk/bin/java"))
+        assertTrue(AppLaunchCommand.isJavaExecutable("C:\\hosted\\jdk\\bin\\java.exe"))
+        assertFalse(AppLaunchCommand.isJavaExecutable("/Applications/Daemonitor.app/Contents/MacOS/Daemonitor"))
+    }
+
+    @Test
+    fun `builds unix and windows java executable paths with trailing separators trimmed`() {
+        assertEquals(
+            "/opt/jdk/bin/java",
+            AppLaunchCommand.javaExecutablePath("/opt/jdk/", "Linux"),
+        )
+        assertEquals(
+            "C:\\hosted\\jdk\\bin\\java.exe",
+            AppLaunchCommand.javaExecutablePath("C:\\hosted\\jdk\\", "Windows Server 2025"),
+        )
+    }
+
+    @Test
+    fun `extracts mac app bundle path when present`() {
+        assertEquals(
+            "/Applications/Daemonitor.app",
+            AppLaunchCommand.macAppBundlePath("/Applications/Daemonitor.app/Contents/MacOS/Daemonitor"),
+        )
+        assertNull(AppLaunchCommand.macAppBundlePath("/opt/Daemonitor/bin/Daemonitor"))
+    }
+
+    @Test
+    fun `buildCommand applies mode options for packaged and classpath launches`() {
+        val desktop = AppLaunchCommand.buildCommand(
+            executable = "/Applications/Daemonitor.app/Contents/MacOS/Daemonitor",
+            javaHome = "/unused",
+            classpath = "unused",
+            osName = "Mac OS X",
+            options = AppLaunchCommand.Options(reopenMacDesktopBundle = true),
+        )
+        assertEquals(listOf("/usr/bin/open", "-n", "/Applications/Daemonitor.app"), desktop)
+
+        val headless = AppLaunchCommand.buildCommand(
+            executable = "/opt/jdk/bin/java",
+            javaHome = "/opt/jdk",
+            classpath = "app.jar",
+            osName = "Linux",
+            options = AppLaunchCommand.Options(extraArgs = listOf("--headless")),
+        )
+        assertEquals(
+            listOf(
+                "/opt/jdk/bin/java",
+                "-cp",
+                "app.jar",
+                "io.github.cdsap.daemonitor.Daemonitor",
+                "--headless",
+            ),
+            headless,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#86: Refactor mode switcher command construction to a shared launcher helper

Fixes #86

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`