### PR TITLE
fix: separate configuration policy from platform directories

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Defaults.kt
@@ -1,75 +1,16 @@
 package io.github.cdsap.daemonitor
 
-import java.nio.file.Path
-import kotlin.io.path.Path
-import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
-
 /**
- * Hard-coded MVP configuration (KTD-9). There is no configuration UI in v1; these constants
- * are the single source of truth for tunable behavior. The configuration surface is deferred.
+ * Remaining hard-coded MVP policy that is neither monitoring cadence nor retention
+ * (KTD-9). Poll/log limits live in [io.github.cdsap.daemonitor.config.MonitoringConfig];
+ * retention in [io.github.cdsap.daemonitor.config.RetentionPolicy]; paths in
+ * [io.github.cdsap.daemonitor.platform.AppDirectories].
  */
 object Defaults {
-    /** How often the process collector samples (KTD-2). */
-    val POLL_INTERVAL: Duration = 2.seconds
-
-    /** Number of daemon-log lines retained for the live tail. */
-    const val LOG_TAIL_LINES: Int = 100
-
-    /** Maximum persisted build-log excerpt, independently bounded by lines and characters. */
-    const val LOG_SNIPPET_LINES: Int = 100
-    const val LOG_SNIPPET_CHARS: Int = 16_000
-
-    /** Default history retention window, in days; user-configurable via Settings (KTD-5). Rows
-     *  older than the configured window are purged on startup and whenever the setting changes. */
-    const val DEFAULT_RETENTION_DAYS: Long = 15
-
-    /** Allowed retention range offered in Settings. */
-    const val MIN_RETENTION_DAYS: Long = 1
-    const val MAX_RETENTION_DAYS: Long = 90
-
-    /** Retention choices shared by Settings and the Historical view filter. */
-    val RETENTION_PRESETS: List<Long> = listOf(7, 15, 30, 60, 90)
-
     /** Default localhost port for the optional MCP HTTP endpoint exposed from Settings. */
     const val DEFAULT_MCP_PORT: Int = 17333
 
     /** Memory highlight thresholds, in MiB of RSS (U9). */
     const val MEM_WARN_MB: Long = 4_096
     const val MEM_CRIT_MB: Long = 8_192
-
-    /** Gradle user home; daemon logs live under `<gradleUserHome>/daemon/<version>/`. */
-    val GRADLE_USER_HOME: Path =
-        Path(System.getProperty("user.home"), ".gradle")
-
-    /**
-     * Per-user application-data directory for the SQLite database and settings, following each
-     * platform's convention so the app is portable:
-     *   - Windows: `%LOCALAPPDATA%\Daemonitor` (fallback `~/AppData/Local`)
-     *   - macOS:   `~/Library/Application Support/Daemonitor`
-     *   - Linux/other: `$XDG_DATA_HOME/Daemonitor` (fallback `~/.local/share`)
-     */
-    val APP_SUPPORT_DIR: Path = run {
-        val home = System.getProperty("user.home")
-        val osName = System.getProperty("os.name").lowercase()
-        when {
-            osName.contains("win") -> {
-                val localAppData = System.getenv("LOCALAPPDATA")
-                if (!localAppData.isNullOrBlank()) Path(localAppData, "Daemonitor")
-                else Path(home, "AppData", "Local", "Daemonitor")
-            }
-            osName.contains("mac") || osName.contains("darwin") ->
-                Path(home, "Library", "Application Support", "Daemonitor")
-            else -> {
-                val xdg = System.getenv("XDG_DATA_HOME")
-                if (!xdg.isNullOrBlank()) Path(xdg, "Daemonitor")
-                else Path(home, ".local", "share", "Daemonitor")
-            }
-        }
-    }
-
-    val DATABASE_PATH: Path = APP_SUPPORT_DIR.resolve("watcher.db")
-
-    /** Settings file (Java properties) alongside the database. */
-    val SETTINGS_PATH: Path = APP_SUPPORT_DIR.resolve("settings.properties")
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -2,6 +2,7 @@
 
 package io.github.cdsap.daemonitor
 
+import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import kotlinx.coroutines.CancellationException
@@ -65,7 +66,7 @@ internal object HeadlessLauncher {
                 while (currentCoroutineContext().isActive && running.get()) {
                     runCatching { runtime.pollOnce() }
                         .onFailure { error.println("Daemonitor poll failed: ${it.message}") }
-                    delay(Defaults.POLL_INTERVAL)
+                    delay(MonitoringConfig.DEFAULT.pollInterval)
                 }
             }
             0

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor
 
+import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.store.Settings
 import io.github.cdsap.daemonitor.store.SettingsStore
@@ -78,7 +79,7 @@ class WatcherService(
         boundScope.launch(ioDispatcher) {
             while (isActive) {
                 pollSafely()
-                delay(Defaults.POLL_INTERVAL)
+                delay(MonitoringConfig.DEFAULT.pollInterval)
             }
         }
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/collect/DaemonLogWatcher.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/collect/DaemonLogWatcher.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.daemonitor.collect
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.MonitoringConfig
+import io.github.cdsap.daemonitor.platform.AppDirectories
 import io.github.cdsap.daemonitor.domain.Redactor
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
 import java.io.ByteArrayOutputStream
@@ -29,8 +30,8 @@ data class DaemonLogLine(val text: String, val event: BuildEvent?)
  * single registration.
  */
 class DaemonLogWatcher(
-    private val gradleUserHome: Path = Defaults.GRADLE_USER_HOME,
-    private val tailLines: Int = Defaults.LOG_TAIL_LINES,
+    private val gradleUserHome: Path = AppDirectories.system.gradleUserHome,
+    private val tailLines: Int = MonitoringConfig.DEFAULT.logTailLines,
     private val initialReadBytes: Int = DEFAULT_INITIAL_READ_BYTES,
     private val readChunkBytes: Int = DEFAULT_READ_CHUNK_BYTES,
 ) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/config/MonitoringConfig.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/config/MonitoringConfig.kt
@@ -1,0 +1,29 @@
+package io.github.cdsap.daemonitor.config
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/** Bounds for persisted build-log excerpts (lines and characters). */
+data class LogSnippetLimit(
+    val lines: Int,
+    val chars: Int,
+)
+
+/**
+ * Application monitoring policy — poll cadence and log limits.
+ * Independent of filesystem / OS path discovery.
+ */
+data class MonitoringConfig(
+    val pollInterval: Duration,
+    val logTailLines: Int,
+    val logSnippetLimit: LogSnippetLimit,
+) {
+    companion object {
+        /** Hard-coded MVP defaults (KTD-9); values unchanged from the previous [io.github.cdsap.daemonitor.Defaults]. */
+        val DEFAULT: MonitoringConfig = MonitoringConfig(
+            pollInterval = 2.seconds,
+            logTailLines = 100,
+            logSnippetLimit = LogSnippetLimit(lines = 100, chars = 16_000),
+        )
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/config/RetentionPolicy.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/config/RetentionPolicy.kt
@@ -1,0 +1,24 @@
+package io.github.cdsap.daemonitor.config
+
+/**
+ * History retention policy — default window, allowed range, and UI presets.
+ * Independent of filesystem / OS path discovery.
+ */
+data class RetentionPolicy(
+    val defaultDays: Long,
+    val minDays: Long,
+    val maxDays: Long,
+    val presets: List<Long>,
+) {
+    fun clamp(days: Long): Long = days.coerceIn(minDays, maxDays)
+
+    companion object {
+        /** Hard-coded MVP defaults (KTD-5 / KTD-9); values unchanged from the previous Defaults. */
+        val DEFAULT: RetentionPolicy = RetentionPolicy(
+            defaultDays = 15,
+            minDays = 1,
+            maxDays = 90,
+            presets = listOf(7, 15, 30, 60, 90),
+        )
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.domain
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
@@ -121,10 +121,11 @@ class BuildAggregator(
         private var logChars = 0
 
         fun appendLogLine(line: String) {
-            val boundedLine = line.takeLast(Defaults.LOG_SNIPPET_CHARS)
+            val snippetLimit = MonitoringConfig.DEFAULT.logSnippetLimit
+            val boundedLine = line.takeLast(snippetLimit.chars)
             logLines.addLast(boundedLine)
             logChars += boundedLine.length + if (logLines.size > 1) 1 else 0
-            while (logLines.size > Defaults.LOG_SNIPPET_LINES || logChars > Defaults.LOG_SNIPPET_CHARS) {
+            while (logLines.size > snippetLimit.lines || logChars > snippetLimit.chars) {
                 val removed = logLines.removeFirst()
                 logChars -= removed.length + if (logLines.isNotEmpty()) 1 else 0
             }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/platform/AppDirectories.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/platform/AppDirectories.kt
@@ -1,0 +1,68 @@
+package io.github.cdsap.daemonitor.platform
+
+import java.nio.file.Path
+import kotlin.io.path.Path
+
+/**
+ * Platform application directories — database, settings, and Gradle user home.
+ * Path discovery stays at the infrastructure/platform edge; application policy does not live here.
+ */
+data class AppDirectories(
+    val databasePath: Path,
+    val settingsPath: Path,
+    val gradleUserHome: Path,
+    val appSupportDir: Path,
+) {
+    /** Staging directory for downloaded / extracted update artifacts. */
+    val updatesDirectory: Path get() = appSupportDir.resolve("updates")
+
+    companion object {
+        /** Process-wide directories discovered from the current environment. */
+        val system: AppDirectories by lazy { discover() }
+
+        /**
+         * Resolve per-user application-data and Gradle paths from [home], [osName], and [getenv].
+         * Injectable for tests; production callers use [system].
+         *
+         * Platform conventions (unchanged):
+         *   - Windows: `%LOCALAPPDATA%\Daemonitor` (fallback `~/AppData/Local`)
+         *   - macOS:   `~/Library/Application Support/Daemonitor`
+         *   - Linux/other: `$XDG_DATA_HOME/Daemonitor` (fallback `~/.local/share`)
+         */
+        fun discover(
+            home: String = System.getProperty("user.home"),
+            osName: String = System.getProperty("os.name"),
+            getenv: (String) -> String? = System::getenv,
+        ): AppDirectories {
+            val appSupportDir = resolveAppSupportDir(home, osName, getenv)
+            return AppDirectories(
+                databasePath = appSupportDir.resolve("watcher.db"),
+                settingsPath = appSupportDir.resolve("settings.properties"),
+                gradleUserHome = Path(home, ".gradle"),
+                appSupportDir = appSupportDir,
+            )
+        }
+
+        private fun resolveAppSupportDir(
+            home: String,
+            osName: String,
+            getenv: (String) -> String?,
+        ): Path {
+            val normalized = osName.lowercase()
+            return when {
+                normalized.contains("win") -> {
+                    val localAppData = getenv("LOCALAPPDATA")
+                    if (!localAppData.isNullOrBlank()) Path(localAppData, "Daemonitor")
+                    else Path(home, "AppData", "Local", "Daemonitor")
+                }
+                normalized.contains("mac") || normalized.contains("darwin") ->
+                    Path(home, "Library", "Application Support", "Daemonitor")
+                else -> {
+                    val xdg = getenv("XDG_DATA_HOME")
+                    if (!xdg.isNullOrBlank()) Path(xdg, "Daemonitor")
+                    else Path(home, ".local", "share", "Daemonitor")
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/SettingsStore.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/SettingsStore.kt
@@ -1,6 +1,8 @@
 package io.github.cdsap.daemonitor.store
 
 import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
+import io.github.cdsap.daemonitor.platform.AppDirectories
 import java.nio.file.Files
 import java.nio.file.Path
 import java.security.SecureRandom
@@ -12,7 +14,7 @@ import kotlin.io.path.outputStream
 
 /** User-configurable settings (KTD-9 deferred config, now partially realized). */
 data class Settings(
-    val retentionDays: Long = Defaults.DEFAULT_RETENTION_DAYS,
+    val retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays,
     val appearance: AppearancePreference = AppearancePreference.SYSTEM,
     val mcpEnabled: Boolean = false,
     val mcpPort: Int = Defaults.DEFAULT_MCP_PORT,
@@ -27,15 +29,16 @@ enum class AppearancePreference { SYSTEM, LIGHT, DARK }
  * a schema migration. Reads are defensive — a missing/corrupt file or out-of-range value falls back
  * to the default rather than failing the app.
  */
-class SettingsStore(private val path: Path = Defaults.SETTINGS_PATH) {
+class SettingsStore(private val path: Path = AppDirectories.system.settingsPath) {
 
     fun load(): Settings {
         if (!path.exists()) return Settings(mcpToken = newMcpToken())
         val props = Properties()
         runCatching { path.inputStream().use { props.load(it) } }
+        val retentionPolicy = RetentionPolicy.DEFAULT
         val retention = props.getProperty(KEY_RETENTION)?.toLongOrNull()
-            ?.coerceIn(Defaults.MIN_RETENTION_DAYS, Defaults.MAX_RETENTION_DAYS)
-            ?: Defaults.DEFAULT_RETENTION_DAYS
+            ?.let(retentionPolicy::clamp)
+            ?: retentionPolicy.defaultDays
         val appearance = props.getProperty(KEY_APPEARANCE)
             ?.let { stored -> AppearancePreference.entries.firstOrNull { it.name.equals(stored, ignoreCase = true) } }
             ?: AppearancePreference.SYSTEM

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
@@ -4,7 +4,8 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import app.cash.sqldelight.db.SqlDriver
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
+import io.github.cdsap.daemonitor.platform.AppDirectories
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
@@ -137,7 +138,7 @@ class WatcherDatabase private constructor(
         db.watcherQueries.distinctProjects().asFlow().mapToList(ioDispatcher)
 
     /** Delete samples and builds older than [retentionDays] before [nowMs] (KTD-5). */
-    fun purgeOlderThan(nowMs: Long, retentionDays: Long = Defaults.DEFAULT_RETENTION_DAYS) {
+    fun purgeOlderThan(nowMs: Long, retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays) {
         val cutoff = nowMs - retentionDays * 24 * 60 * 60 * 1000
         db.watcherQueries.purgeSamplesOlderThan(cutoff)
         db.watcherQueries.purgeBuildsOlderThan(cutoff)
@@ -146,7 +147,7 @@ class WatcherDatabase private constructor(
     companion object {
         /** Open (creating if necessary) the database at [path], applying privacy hardening. */
         fun open(
-            path: Path = Defaults.DATABASE_PATH,
+            path: Path = AppDirectories.system.databasePath,
             ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
         ): WatcherDatabase {
             val isNew = !path.exists()

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryFilter.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryFilter.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.ui.history
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.domain.model.Build
 
 /** Rolling time ranges aligned with the history-retention choices in Settings. */
@@ -21,12 +21,12 @@ enum class TimeRange(val days: Long) {
         private const val DAY_MS = 24L * 60 * 60 * 1000
 
         init {
-            check(entries.map(TimeRange::days) == Defaults.RETENTION_PRESETS) {
+            check(entries.map(TimeRange::days) == RetentionPolicy.DEFAULT.presets) {
                 "Historical ranges must match the configured retention presets"
             }
         }
 
-        val DEFAULT: TimeRange = entries.single { it.days == Defaults.DEFAULT_RETENTION_DAYS }
+        val DEFAULT: TimeRange = entries.single { it.days == RetentionPolicy.DEFAULT.defaultDays }
     }
 }
 

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.ui.common.SectionCard
 import io.github.cdsap.daemonitor.ui.common.ScreenHeader
@@ -199,13 +199,13 @@ fun SettingsScreen(
                 Spacer(Modifier.height(Space.sm))
                 Text(
                     "Entries older than this are removed on startup and immediately when you lower it. " +
-                        "Range ${Defaults.MIN_RETENTION_DAYS}–${Defaults.MAX_RETENTION_DAYS} days; default ${Defaults.DEFAULT_RETENTION_DAYS}.",
+                        "Range ${RetentionPolicy.DEFAULT.minDays}–${RetentionPolicy.DEFAULT.maxDays} days; default ${RetentionPolicy.DEFAULT.defaultDays}.",
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
                 Spacer(Modifier.height(Space.md))
                 Row(horizontalArrangement = Arrangement.spacedBy(Space.sm)) {
-                    Defaults.RETENTION_PRESETS.forEach { days ->
+                    RetentionPolicy.DEFAULT.presets.forEach { days ->
                         FilterChip(
                             selected = state.retentionDays == days,
                             onClick = { onRetentionDays(days) },

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.daemonitor.ui.settings
 
 import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
 import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
@@ -24,7 +25,7 @@ import kotlinx.coroutines.launch
 
 /** Immutable state the Settings screen renders. */
 data class SettingsUiState(
-    val retentionDays: Long = Defaults.DEFAULT_RETENTION_DAYS,
+    val retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays,
     val appearance: AppearancePreference = AppearancePreference.SYSTEM,
     val updateState: UpdateUiState = UpdateUiState.NotChecked,
     val mcpEnabled: Boolean = false,
@@ -83,7 +84,7 @@ class SettingsViewModel(
     val state: StateFlow<SettingsUiState> = _state.asStateFlow()
 
     fun setRetentionDays(days: Long) {
-        val clamped = days.coerceIn(Defaults.MIN_RETENTION_DAYS, Defaults.MAX_RETENTION_DAYS)
+        val clamped = RetentionPolicy.DEFAULT.clamp(days)
         if (clamped == _state.value.retentionDays) return
         _state.value = _state.value.copy(retentionDays = clamped)
         onRetentionChange(clamped)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/update/UpdateInstaller.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.update
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.platform.AppDirectories
 import java.awt.Desktop
 import java.net.URI
 import java.net.http.HttpClient
@@ -27,7 +27,7 @@ fun interface UpdateInstaller {
 }
 
 class DesktopUpdateInstaller(
-    private val updateDirectory: Path = Defaults.APP_SUPPORT_DIR.resolve("updates"),
+    private val updateDirectory: Path = AppDirectories.system.updatesDirectory,
     private val installation: InstallationInfo = InstallationLocator.current(),
     private val opener: (Path) -> Unit = ::openWithDesktop,
     private val downloader: suspend (UpdateCandidate, Path, (Double?) -> Unit) -> Path = ::downloadAndVerify,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/config/PolicyDefaultsTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/config/PolicyDefaultsTest.kt
@@ -1,0 +1,34 @@
+package io.github.cdsap.daemonitor.config
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class PolicyDefaultsTest {
+
+    @Test
+    fun `monitoring defaults match prior hard-coded values`() {
+        val config = MonitoringConfig.DEFAULT
+        assertEquals(2.seconds, config.pollInterval)
+        assertEquals(100, config.logTailLines)
+        assertEquals(100, config.logSnippetLimit.lines)
+        assertEquals(16_000, config.logSnippetLimit.chars)
+    }
+
+    @Test
+    fun `retention defaults match prior hard-coded values`() {
+        val policy = RetentionPolicy.DEFAULT
+        assertEquals(15, policy.defaultDays)
+        assertEquals(1, policy.minDays)
+        assertEquals(90, policy.maxDays)
+        assertEquals(listOf(7L, 15L, 30L, 60L, 90L), policy.presets)
+    }
+
+    @Test
+    fun `retention clamp respects min and max`() {
+        val policy = RetentionPolicy.DEFAULT
+        assertEquals(1, policy.clamp(0))
+        assertEquals(90, policy.clamp(9_999))
+        assertEquals(30, policy.clamp(30))
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.domain
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
 import io.github.cdsap.daemonitor.domain.model.BuildStart
@@ -103,16 +103,17 @@ class BuildAggregatorTest {
         val agg = BuildAggregator()
         agg.onLogLine(pid, "busy", BusyMark(1_000))
         agg.onLogLine(pid, "start", start(1_010))
-        repeat(Defaults.LOG_SNIPPET_LINES + 5) { index ->
+        val snippetLimit = MonitoringConfig.DEFAULT.logSnippetLimit
+        repeat(snippetLimit.lines + 5) { index ->
             agg.onLogLine(pid, "line-$index-${"x".repeat(200)}", null)
         }
 
         val b = agg.onDaemonGone(pid)!!
         val snippet = b.logSnippet!!
         assertEquals(FinalStatus.INTERRUPTED, b.finalStatus)
-        assertTrue(snippet.lines().size <= Defaults.LOG_SNIPPET_LINES)
-        assertTrue(snippet.length <= Defaults.LOG_SNIPPET_CHARS)
-        assertTrue(snippet.contains("line-${Defaults.LOG_SNIPPET_LINES + 4}"))
+        assertTrue(snippet.lines().size <= snippetLimit.lines)
+        assertTrue(snippet.length <= snippetLimit.chars)
+        assertTrue(snippet.contains("line-${snippetLimit.lines + 4}"))
     }
 
     @Test

--- a/src/test/kotlin/io/github/cdsap/daemonitor/platform/AppDirectoriesTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/platform/AppDirectoriesTest.kt
@@ -1,0 +1,68 @@
+package io.github.cdsap.daemonitor.platform
+
+import kotlin.io.path.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppDirectoriesTest {
+
+    @Test
+    fun `discovers macOS application support paths`() {
+        val dirs = AppDirectories.discover(
+            home = "/Users/ada",
+            osName = "Mac OS X",
+            getenv = { null },
+        )
+        assertEquals(Path("/Users/ada/Library/Application Support/Daemonitor"), dirs.appSupportDir)
+        assertEquals(Path("/Users/ada/Library/Application Support/Daemonitor/watcher.db"), dirs.databasePath)
+        assertEquals(
+            Path("/Users/ada/Library/Application Support/Daemonitor/settings.properties"),
+            dirs.settingsPath,
+        )
+        assertEquals(Path("/Users/ada/.gradle"), dirs.gradleUserHome)
+        assertEquals(Path("/Users/ada/Library/Application Support/Daemonitor/updates"), dirs.updatesDirectory)
+    }
+
+    @Test
+    fun `discovers Windows LOCALAPPDATA when set`() {
+        val dirs = AppDirectories.discover(
+            home = "C:\\Users\\ada",
+            osName = "Windows 11",
+            getenv = { key -> if (key == "LOCALAPPDATA") "D:\\LocalAppData" else null },
+        )
+        assertEquals(Path("D:\\LocalAppData", "Daemonitor"), dirs.appSupportDir)
+        assertEquals(Path("D:\\LocalAppData", "Daemonitor", "watcher.db"), dirs.databasePath)
+        assertEquals(Path("C:\\Users\\ada", ".gradle"), dirs.gradleUserHome)
+    }
+
+    @Test
+    fun `falls back to AppData Local on Windows without LOCALAPPDATA`() {
+        val dirs = AppDirectories.discover(
+            home = "C:\\Users\\ada",
+            osName = "Windows 11",
+            getenv = { null },
+        )
+        assertEquals(Path("C:\\Users\\ada", "AppData", "Local", "Daemonitor"), dirs.appSupportDir)
+    }
+
+    @Test
+    fun `discovers Linux XDG_DATA_HOME when set`() {
+        val dirs = AppDirectories.discover(
+            home = "/home/ada",
+            osName = "Linux",
+            getenv = { key -> if (key == "XDG_DATA_HOME") "/var/data" else null },
+        )
+        assertEquals(Path("/var/data/Daemonitor"), dirs.appSupportDir)
+        assertEquals(Path("/home/ada/.gradle"), dirs.gradleUserHome)
+    }
+
+    @Test
+    fun `falls back to local share on Linux without XDG_DATA_HOME`() {
+        val dirs = AppDirectories.discover(
+            home = "/home/ada",
+            osName = "Linux",
+            getenv = { null },
+        )
+        assertEquals(Path("/home/ada/.local/share/Daemonitor"), dirs.appSupportDir)
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/SettingsStoreTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/SettingsStoreTest.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.daemonitor.store
 
 import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.Test
@@ -13,7 +14,7 @@ class SettingsStoreTest {
     fun `missing file returns defaults`(@TempDir tmp: Path) {
         val store = SettingsStore(tmp.resolve("settings.properties"))
         val settings = store.load()
-        assertEquals(Defaults.DEFAULT_RETENTION_DAYS, settings.retentionDays)
+        assertEquals(RetentionPolicy.DEFAULT.defaultDays, settings.retentionDays)
         assertEquals(AppearancePreference.SYSTEM, settings.appearance)
         assertFalse(settings.mcpEnabled)
         assertEquals(Defaults.DEFAULT_MCP_PORT, settings.mcpPort)
@@ -42,7 +43,7 @@ class SettingsStoreTest {
     fun `out-of-range stored value is clamped on load`(@TempDir tmp: Path) {
         val path = tmp.resolve("settings.properties")
         SettingsStore(path).save(Settings(retentionDays = 9_999))
-        assertEquals(Defaults.MAX_RETENTION_DAYS, SettingsStore(path).load().retentionDays)
+        assertEquals(RetentionPolicy.DEFAULT.maxDays, SettingsStore(path).load().retentionDays)
     }
 
     @Test

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryViewModelTest.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.ui.history
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.Source
@@ -33,8 +33,8 @@ class HistoryViewModelTest {
 
     @Test
     fun `time-range presets match retention choices and use rolling day cutoffs`() {
-        assertEquals(Defaults.RETENTION_PRESETS, TimeRange.entries.map(TimeRange::days))
-        assertEquals(Defaults.DEFAULT_RETENTION_DAYS, TimeRange.DEFAULT.days)
+        assertEquals(RetentionPolicy.DEFAULT.presets, TimeRange.entries.map(TimeRange::days))
+        assertEquals(RetentionPolicy.DEFAULT.defaultDays, TimeRange.DEFAULT.days)
         TimeRange.entries.forEach { range ->
             assertEquals(now - range.days * dayMs, range.cutoffMs(now))
         }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -1,6 +1,6 @@
 package io.github.cdsap.daemonitor.ui.settings
 
-import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.update.StagedUpdate
 import io.github.cdsap.daemonitor.update.UpdateApplier
@@ -47,7 +47,7 @@ class SettingsViewModelTest {
     fun `out-of-range value is clamped`() {
         val vm = SettingsViewModel()
         vm.setRetentionDays(9_999)
-        assertEquals(Defaults.MAX_RETENTION_DAYS, vm.state.value.retentionDays)
+        assertEquals(RetentionPolicy.DEFAULT.maxDays, vm.state.value.retentionDays)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#98: Separate configuration policy from platform directories

Fixes #98

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`