### PR TITLE
fix: create an application composition root

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
@@ -1,0 +1,74 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
+import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.domain.BuildAggregator
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
+import io.github.cdsap.daemonitor.store.SettingsStore
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
+import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
+import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import io.github.cdsap.daemonitor.update.UpdateApplier
+import io.github.cdsap.daemonitor.update.UpdateInstaller
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import java.nio.file.Path
+
+/**
+ * Application composition root. Owns concrete infrastructure wiring so entry points stay thin
+ * bootstrappers and application/presentation code receives dependencies through constructors.
+ */
+class AppContainer(
+    databasePath: Path = Defaults.DATABASE_PATH,
+    settingsPath: Path = Defaults.SETTINGS_PATH,
+    private val clock: () -> Long = System::currentTimeMillis,
+    ambientEnvNames: Set<String> = System.getenv().keys.toSet(),
+) : AutoCloseable {
+    val processCollector = ProcessCollector()
+    val daemonLogWatcher = DaemonLogWatcher()
+    val database = WatcherDatabase.open(databasePath)
+    val settingsStore = SettingsStore(settingsPath)
+    val buildAggregator = BuildAggregator(
+        sampleProvider = database::samplesInWindow,
+        ambientEnvNames = ambientEnvNames,
+    )
+    val runtime = WatcherRuntime(
+        collector = processCollector,
+        logWatcher = daemonLogWatcher,
+        aggregator = buildAggregator,
+        database = database,
+        clock = clock,
+    )
+    val updateSource = GitHubReleaseUpdateSource()
+    val updateInstaller: UpdateInstaller = DesktopUpdateInstaller()
+    val updateApplier: UpdateApplier = DesktopUpdateApplier()
+
+    fun createDesktopService(
+        uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ): WatcherService = WatcherService(
+        runtime = runtime,
+        database = database,
+        settingsStore = settingsStore,
+        clock = clock,
+        updateChecker = { updateSource.check(BuildInfo.current.version) },
+        updateInstaller = updateInstaller,
+        updateApplier = updateApplier,
+        mcpServerFactory = ::createMcpServer,
+        uiDispatcher = uiDispatcher,
+        ioDispatcher = ioDispatcher,
+    )
+
+    fun createMcpServer(
+        currentProcessesProvider: () -> List<GradleProcess> = processCollector::poll,
+    ): DaemonitorMcpServer = DaemonitorMcpServer(
+        database = database,
+        currentProcessesProvider = currentProcessesProvider,
+    )
+
+    override fun close() {
+        database.close()
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -2,8 +2,6 @@
 
 package io.github.cdsap.daemonitor
 
-import io.github.cdsap.daemonitor.store.SettingsStore
-import io.github.cdsap.daemonitor.store.WatcherDatabase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -30,9 +28,18 @@ internal object HeadlessLauncher {
         }
 
         HeadlessMacMode.configure()
-        val database = WatcherDatabase.open()
-        val runtime = WatcherRuntime.create(database)
-        val retentionDays = SettingsStore().load().retentionDays
+        return AppContainer().use { container ->
+            runHeadless(container, output, error)
+        }
+    }
+
+    private fun runHeadless(
+        container: AppContainer,
+        output: PrintStream,
+        error: PrintStream,
+    ): Int {
+        val runtime = container.runtime
+        val retentionDays = container.settingsStore.load().retentionDays
         val pollingThread = Thread.currentThread()
         val running = AtomicBoolean(true)
         val cleanupFinished = CountDownLatch(1)
@@ -58,7 +65,7 @@ internal object HeadlessLauncher {
         )
 
         return try {
-            database.purgeOlderThan(System.currentTimeMillis(), retentionDays)
+            container.database.purgeOlderThan(System.currentTimeMillis(), retentionDays)
             Runtime.getRuntime().addShutdownHook(shutdownHook)
             output.println("Daemonitor headless collector started")
             runBlocking {
@@ -75,9 +82,8 @@ internal object HeadlessLauncher {
             0
         } finally {
             try {
-                database.close()
-            } finally {
                 tray.close()
+            } finally {
                 cleanupFinished.countDown()
                 runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
             }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -32,8 +32,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 /**
- * Application entry point (U1 scaffold, wired in U7). Opens the database, starts the polling
- * [WatcherService], and renders the tabbed UI. The Historical tab is wired in U8.
+ * Application entry point (U1 scaffold, wired in U7). Obtains a wired [WatcherService] from the
+ * composition root, starts polling, and renders the tabbed UI. The Historical tab is wired in U8.
  */
 fun main(args: Array<String>) {
     if (args.firstOrNull() == "--headless") {
@@ -63,7 +63,7 @@ private fun launchDesktop() = application {
         icon = painterResource("icon/daemonitor.png"),
     ) {
         LaunchedEffect(Unit) {
-            service = withContext(Dispatchers.IO) { WatcherService.create() }
+            service = withContext(Dispatchers.IO) { AppContainer().createDesktopService() }
         }
         DaemonitorContent(
             service = service,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -10,8 +10,8 @@ import io.github.cdsap.daemonitor.store.WatcherDatabase
 
 /** UI-independent collection and persistence runtime shared by desktop and headless launchers. */
 class WatcherRuntime(
-    private val collector: ProcessCollector = ProcessCollector(),
-    private val logWatcher: DaemonLogWatcher = DaemonLogWatcher(),
+    private val collector: ProcessCollector,
+    private val logWatcher: DaemonLogWatcher,
     private val aggregator: BuildAggregator,
     private val database: WatcherDatabase,
     private val clock: () -> Long = System::currentTimeMillis,
@@ -73,7 +73,10 @@ class WatcherRuntime(
         filter { it.type == ProcessType.GRADLE_DAEMON }.map { it.pid }.toSet()
 
     companion object {
+        /** Test/helper factory. Production wiring lives in [AppContainer]. */
         fun create(database: WatcherDatabase): WatcherRuntime = WatcherRuntime(
+            collector = ProcessCollector(),
+            logWatcher = DaemonLogWatcher(),
             aggregator = BuildAggregator(
                 sampleProvider = database::samplesInWindow,
                 ambientEnvNames = System.getenv().keys.toSet(),

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -1,18 +1,19 @@
 package io.github.cdsap.daemonitor
 
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpHttpServer
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
 import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.store.Settings
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
-import io.github.cdsap.daemonitor.mcp.DaemonitorMcpHttpServer
-import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
 import io.github.cdsap.daemonitor.ui.history.HistoryViewModel
 import io.github.cdsap.daemonitor.ui.live.LiveViewModel
 import io.github.cdsap.daemonitor.ui.settings.McpUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsViewModel
-import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstaller
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CancellationException
@@ -29,12 +30,13 @@ import kotlinx.coroutines.withContext
 class WatcherService(
     private val runtime: WatcherRuntime,
     private val database: WatcherDatabase,
-    private val settingsStore: SettingsStore = SettingsStore(),
+    private val settingsStore: SettingsStore,
     private val clock: () -> Long = System::currentTimeMillis,
     private val pollAction: suspend () -> WatcherRuntime.PollResult = { runtime.pollOnce() },
-    private val updateChecker: suspend () -> UpdateCheckResult = {
-        GitHubReleaseUpdateSource().check(BuildInfo.current.version)
-    },
+    private val updateChecker: suspend () -> UpdateCheckResult,
+    private val updateInstaller: UpdateInstaller,
+    private val updateApplier: UpdateApplier,
+    private val mcpServerFactory: () -> DaemonitorMcpServer,
     private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
@@ -57,6 +59,8 @@ class WatcherService(
         onAppearanceChange = ::onAppearanceChanged,
         onMcpEnabledChange = ::onMcpEnabledChanged,
         updateChecker = updateChecker,
+        updateInstaller = updateInstaller,
+        updateApplier = updateApplier,
         scope = CoroutineScope(SupervisorJob() + uiDispatcher),
     )
 
@@ -139,7 +143,7 @@ class WatcherService(
                 DaemonitorMcpHttpServer.start(
                     port = state.mcpPort,
                     token = state.mcpToken,
-                    server = DaemonitorMcpServer(database),
+                    server = mcpServerFactory(),
                 )
             }.onSuccess { server ->
                 if (!settingsViewModel.state.value.mcpEnabled) {
@@ -225,11 +229,7 @@ class WatcherService(
     }
 
     companion object {
-        /** Build a fully wired service against the real database. */
-        fun create(database: WatcherDatabase = WatcherDatabase.open()): WatcherService =
-            WatcherService(
-                runtime = WatcherRuntime.create(database),
-                database = database,
-            )
+        /** Build a fully wired desktop service via the application composition root. */
+        fun create(): WatcherService = AppContainer().createDesktopService()
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
@@ -1,7 +1,7 @@
 package io.github.cdsap.daemonitor.mcp
 
+import io.github.cdsap.daemonitor.AppContainer
 import io.github.cdsap.daemonitor.BuildInfo
-import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.store.ProcessSample
@@ -14,7 +14,7 @@ import java.nio.charset.StandardCharsets
 
 class DaemonitorMcpServer(
     private val database: WatcherDatabase,
-    private val currentProcessesProvider: () -> List<GradleProcess> = ProcessCollector()::poll,
+    private val currentProcessesProvider: () -> List<GradleProcess>,
 ) {
     internal fun handle(request: JsonObject): JsonObject? {
         val id = request.values["id"]
@@ -281,13 +281,12 @@ class DaemonitorMcpServer(
 
 object DaemonitorMcpStdio {
     fun run(
-        database: WatcherDatabase = WatcherDatabase.open(),
+        container: AppContainer = AppContainer(),
         input: InputStream = System.`in`,
         output: OutputStream = System.out,
     ) {
-        database.use {
-            val server = DaemonitorMcpServer(it)
-            McpMessageStream(input, output).serve(server)
+        container.use {
+            McpMessageStream(input, output).serve(it.createMcpServer())
         }
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -1,11 +1,7 @@
 package io.github.cdsap.daemonitor.ui.settings
 
-import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.store.AppearancePreference
-import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
-import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
-import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
 import io.github.cdsap.daemonitor.update.StagedUpdate
 import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCandidate
@@ -71,10 +67,14 @@ class SettingsViewModel(
     private val onAppearanceChange: (AppearancePreference) -> Unit = {},
     private val onMcpEnabledChange: (Boolean) -> Unit = {},
     private val updateChecker: suspend () -> UpdateCheckResult = {
-        GitHubReleaseUpdateSource().check(BuildInfo.current.version)
+        UpdateCheckResult.Failed("Update checker not configured")
     },
-    private val updateInstaller: UpdateInstaller = DesktopUpdateInstaller(),
-    private val updateApplier: UpdateApplier = DesktopUpdateApplier(),
+    private val updateInstaller: UpdateInstaller = UpdateInstaller { _, _ ->
+        error("Update installer not configured")
+    },
+    private val updateApplier: UpdateApplier = UpdateApplier {
+        error("Update applier not configured")
+    },
     private val onExitForUpdate: () -> Unit = { kotlin.system.exitProcess(0) },
     private val releaseOpener: (String) -> Unit = ::openReleaseUrl,
     private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),

--- a/src/test/kotlin/io/github/cdsap/daemonitor/AppContainerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/AppContainerTest.kt
@@ -1,0 +1,67 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
+import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.domain.BuildAggregator
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
+import io.github.cdsap.daemonitor.store.Settings
+import io.github.cdsap.daemonitor.store.SettingsStore
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
+import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
+import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+
+class AppContainerTest {
+    @Test
+    fun `container owns concrete infrastructure wiring`(@TempDir tmp: Path) {
+        AppContainer(
+            databasePath = tmp.resolve("watcher.db"),
+            settingsPath = tmp.resolve("settings.properties"),
+        ).use { container ->
+            assertIs<ProcessCollector>(container.processCollector)
+            assertIs<DaemonLogWatcher>(container.daemonLogWatcher)
+            assertIs<WatcherDatabase>(container.database)
+            assertIs<SettingsStore>(container.settingsStore)
+            assertIs<BuildAggregator>(container.buildAggregator)
+            assertIs<WatcherRuntime>(container.runtime)
+            assertIs<GitHubReleaseUpdateSource>(container.updateSource)
+            assertIs<DesktopUpdateInstaller>(container.updateInstaller)
+            assertIs<DesktopUpdateApplier>(container.updateApplier)
+
+            assertIs<WatcherService>(container.createDesktopService())
+            assertIs<DaemonitorMcpServer>(
+                container.createMcpServer(currentProcessesProvider = { emptyList() }),
+            )
+        }
+    }
+
+    @Test
+    fun `container settings store uses configured path`(@TempDir tmp: Path) {
+        val settingsPath = tmp.resolve("settings.properties")
+        AppContainer(
+            databasePath = tmp.resolve("watcher.db"),
+            settingsPath = settingsPath,
+        ).use { container ->
+            container.settingsStore.save(Settings(retentionDays = 30))
+            assertEquals(30L, SettingsStore(settingsPath).load().retentionDays)
+        }
+    }
+
+    @Test
+    fun `mcp stdio bootstrapper accepts a composition root`(@TempDir tmp: Path) {
+        // DaemonitorMcpStdio.run takes ownership and closes the container.
+        io.github.cdsap.daemonitor.mcp.DaemonitorMcpStdio.run(
+            container = AppContainer(
+                databasePath = tmp.resolve("watcher.db"),
+                settingsPath = tmp.resolve("settings.properties"),
+            ),
+            input = java.io.ByteArrayInputStream(ByteArray(0)),
+            output = java.io.ByteArrayOutputStream(),
+        )
+    }
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
@@ -1,6 +1,7 @@
 package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
+import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.domain.BuildAggregator
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.store.WatcherDatabase
@@ -27,6 +28,7 @@ class WatcherRuntimeTest {
 
         WatcherDatabase.open(tmp.resolve("watcher.db")).use { database ->
             val runtime = WatcherRuntime(
+                collector = ProcessCollector(),
                 logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle")),
                 aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
                 database = database,
@@ -75,6 +77,7 @@ class WatcherRuntimeTest {
         WatcherDatabase.open(tmp.resolve("watcher.db")).use { database ->
             val logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle"))
             val runtime = WatcherRuntime(
+                collector = ProcessCollector(),
                 logWatcher = logWatcher,
                 aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
                 database = database,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -1,9 +1,12 @@
 package io.github.cdsap.daemonitor
 
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.ui.settings.UpdateUiState
+import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
+import io.github.cdsap.daemonitor.update.UpdateInstaller
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -157,6 +160,11 @@ class WatcherServiceTest {
         clock = clock,
         pollAction = pollAction,
         updateChecker = updateChecker,
+        updateInstaller = UpdateInstaller { _, _ -> null },
+        updateApplier = UpdateApplier { },
+        mcpServerFactory = {
+            DaemonitorMcpServer(database, currentProcessesProvider = { emptyList() })
+        },
         uiDispatcher = uiDispatcher,
         ioDispatcher = uiDispatcher,
     )


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#97: Create an application composition root

Fixes #97

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`