### PR TITLE
fix: add an application query service for mcp

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/DaemonitorMcpStdio.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DaemonitorMcpStdio.kt
@@ -1,0 +1,25 @@
+package io.github.cdsap.daemonitor
+
+import io.github.cdsap.daemonitor.application.DefaultDaemonitorQueryService
+import io.github.cdsap.daemonitor.application.ProcessSource
+import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
+import io.github.cdsap.daemonitor.mcp.McpMessageStream
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import java.io.InputStream
+import java.io.OutputStream
+
+/** Stdio composition root for `--mcp` mode. */
+object DaemonitorMcpStdio {
+    fun run(
+        database: WatcherDatabase = WatcherDatabase.open(),
+        processSource: ProcessSource = ProcessCollector(),
+        input: InputStream = System.`in`,
+        output: OutputStream = System.out,
+    ) {
+        database.use {
+            val server = DaemonitorMcpServer(DefaultDaemonitorQueryService(it, processSource))
+            McpMessageStream(input, output).serve(server)
+        }
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -27,7 +27,6 @@ import io.github.cdsap.daemonitor.ui.history.HistoryScreen
 import io.github.cdsap.daemonitor.ui.live.LiveMonitorScreen
 import io.github.cdsap.daemonitor.ui.live.ProcessVisualScreen
 import io.github.cdsap.daemonitor.ui.settings.SettingsScreen
-import io.github.cdsap.daemonitor.mcp.DaemonitorMcpStdio
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -4,6 +4,8 @@ import io.github.cdsap.daemonitor.store.AppearancePreference
 import io.github.cdsap.daemonitor.store.Settings
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
+import io.github.cdsap.daemonitor.application.DefaultDaemonitorQueryService
+import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.mcp.DaemonitorMcpHttpServer
 import io.github.cdsap.daemonitor.mcp.DaemonitorMcpServer
 import io.github.cdsap.daemonitor.ui.history.HistoryViewModel
@@ -139,7 +141,9 @@ class WatcherService(
                 DaemonitorMcpHttpServer.start(
                     port = state.mcpPort,
                     token = state.mcpToken,
-                    server = DaemonitorMcpServer(database),
+                    server = DaemonitorMcpServer(
+                        DefaultDaemonitorQueryService(database, ProcessCollector()),
+                    ),
                 )
             }.onSuccess { server ->
                 if (!settingsViewModel.state.value.mcpEnabled) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/DaemonitorQueryService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/DaemonitorQueryService.kt
@@ -1,0 +1,20 @@
+package io.github.cdsap.daemonitor.application
+
+import io.github.cdsap.daemonitor.domain.model.Build
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.store.ProcessSample
+
+/** Application-facing read API used by MCP and other query consumers. */
+interface DaemonitorQueryService {
+    fun searchHistory(query: String, limit: Int): List<Build>
+
+    fun buildsForProcess(process: String, limit: Int): ProcessBuildResult
+
+    fun currentProcesses(): List<GradleProcess>
+}
+
+data class ProcessBuildResult(
+    val process: String,
+    val matchedBuilds: List<Build>,
+    val matchedProcessSamples: List<ProcessSample>,
+)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryService.kt
@@ -1,0 +1,51 @@
+package io.github.cdsap.daemonitor.application
+
+import io.github.cdsap.daemonitor.domain.model.Build
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+
+/**
+ * Query service backed by persistence reads and a [ProcessSource].
+ * Keeps MCP free of SQLite and OSHI collection details.
+ */
+class DefaultDaemonitorQueryService(
+    private val database: WatcherDatabase,
+    private val processSource: ProcessSource,
+) : DaemonitorQueryService {
+    override fun searchHistory(query: String, limit: Int): List<Build> =
+        database.searchBuilds(query, limit.coerceQueryLimit())
+
+    override fun buildsForProcess(process: String, limit: Int): ProcessBuildResult {
+        val safeLimit = limit.coerceQueryLimit()
+        val pid = process.toLongOrNull()
+        val builds = if (pid != null) {
+            database.buildsForDaemonPid(pid, safeLimit)
+        } else {
+            database.searchBuilds(process, safeLimit)
+        }
+        val samples = if (pid != null) {
+            database.processSamplesForPid(pid, safeLimit)
+        } else {
+            database.recentProcessSamples(TEXT_MATCH_SAMPLE_SCAN_LIMIT).filter { sample ->
+                sample.commandLine.contains(process, ignoreCase = true) ||
+                    sample.workingDirectory?.contains(process, ignoreCase = true) == true ||
+                    sample.projectPath?.contains(process, ignoreCase = true) == true ||
+                    sample.processType.name.contains(process, ignoreCase = true)
+            }.take(safeLimit.toInt())
+        }
+        return ProcessBuildResult(
+            process = process,
+            matchedBuilds = builds,
+            matchedProcessSamples = samples,
+        )
+    }
+
+    override fun currentProcesses(): List<GradleProcess> = processSource.currentProcesses()
+
+    private fun Int.coerceQueryLimit(): Long = toLong().coerceIn(1, MAX_LIMIT)
+
+    private companion object {
+        const val MAX_LIMIT = 200L
+        const val TEXT_MATCH_SAMPLE_SCAN_LIMIT = 200L
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/ProcessSource.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/ProcessSource.kt
@@ -1,0 +1,8 @@
+package io.github.cdsap.daemonitor.application
+
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+
+/** Application port for the current set of Gradle-related processes. */
+fun interface ProcessSource {
+    fun currentProcesses(): List<GradleProcess>
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/collect/ProcessCollector.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/collect/ProcessCollector.kt
@@ -1,5 +1,6 @@
 package io.github.cdsap.daemonitor.collect
 
+import io.github.cdsap.daemonitor.application.ProcessSource
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.PriorSample
 import io.github.cdsap.daemonitor.domain.model.ProcessInfo
@@ -16,7 +17,7 @@ import oshi.software.os.OSProcess
 class ProcessCollector(
     private val systemInfo: SystemInfo = SystemInfo(),
     private val clock: () -> Long = System::currentTimeMillis,
-) {
+) : ProcessSource {
     private val os = systemInfo.operatingSystem
     private val logicalProcessors = systemInfo.hardware.processor.logicalProcessorCount
     private val selfPid: Int = os.processId
@@ -24,6 +25,8 @@ class ProcessCollector(
 
     /** Prior CPU sample per process, keyed by (pid, startTime) to survive PID reuse (KTD-4). */
     private val priorSamples = mutableMapOf<ProcessKey, PriorSample>()
+
+    override fun currentProcesses(): List<GradleProcess> = poll()
 
     fun poll(): List<GradleProcess> {
         val now = clock()

--- a/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
@@ -1,11 +1,10 @@
 package io.github.cdsap.daemonitor.mcp
 
 import io.github.cdsap.daemonitor.BuildInfo
-import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.application.DaemonitorQueryService
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.store.ProcessSample
-import io.github.cdsap.daemonitor.store.WatcherDatabase
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
 import java.io.InputStream
@@ -13,8 +12,7 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 
 class DaemonitorMcpServer(
-    private val database: WatcherDatabase,
-    private val currentProcessesProvider: () -> List<GradleProcess> = ProcessCollector()::poll,
+    private val queries: DaemonitorQueryService,
 ) {
     internal fun handle(request: JsonObject): JsonObject? {
         val id = request.values["id"]
@@ -164,35 +162,17 @@ class DaemonitorMcpServer(
             ?: throw McpError(-32602, "Missing required argument: process")
         if (process.isEmpty()) throw McpError(-32602, "Process argument cannot be empty")
 
-        val limit = arguments.long("limit").coerceLimit()
-        val pid = process.toLongOrNull()
-        val builds = if (pid != null) {
-            database.buildsForDaemonPid(pid, limit)
-        } else {
-            database.searchBuilds(process, limit)
-        }
-        val samples = if (pid != null) {
-            database.processSamplesForPid(pid, limit)
-        } else {
-            database.recentProcessSamples(200).filter { sample ->
-                sample.commandLine.contains(process, ignoreCase = true) ||
-                    sample.workingDirectory?.contains(process, ignoreCase = true) == true ||
-                    sample.projectPath?.contains(process, ignoreCase = true) == true ||
-                    sample.processType.name.contains(process, ignoreCase = true)
-            }.take(limit.toInt())
-        }
-
+        val result = queries.buildsForProcess(process, arguments.long("limit").coerceLimit())
         return jsonObject(
-            "process" to JsonString(process),
-            "matchedBuilds" to JsonArray(builds.map { it.toJson() }),
-            "matchedProcessSamples" to JsonArray(samples.map { it.toJson() }),
+            "process" to JsonString(result.process),
+            "matchedBuilds" to JsonArray(result.matchedBuilds.map { it.toJson() }),
+            "matchedProcessSamples" to JsonArray(result.matchedProcessSamples.map { it.toJson() }),
         )
     }
 
     private fun searchHistory(arguments: JsonObject): JsonObject {
         val query = arguments.string("query").orEmpty()
-        val limit = arguments.long("limit").coerceLimit()
-        val builds = database.searchBuilds(query, limit)
+        val builds = queries.searchHistory(query, arguments.long("limit").coerceLimit())
         return jsonObject(
             "query" to JsonString(query),
             "builds" to JsonArray(builds.map { it.toJson() }),
@@ -200,7 +180,7 @@ class DaemonitorMcpServer(
     }
 
     private fun currentProcesses(): JsonObject {
-        val processes = currentProcessesProvider()
+        val processes = queries.currentProcesses()
         return jsonObject(
             "processes" to JsonArray(processes.map { it.toJson() }),
         )
@@ -217,7 +197,7 @@ class DaemonitorMcpServer(
             "isError" to JsonBoolean(false),
         )
 
-    private fun Long?.coerceLimit(): Long = (this ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+    private fun Long?.coerceLimit(): Int = (this ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT).toInt()
 
     private fun Build.toJson(): JsonObject = jsonObject(
         "buildId" to JsonString(buildId),
@@ -279,20 +259,7 @@ class DaemonitorMcpServer(
     }
 }
 
-object DaemonitorMcpStdio {
-    fun run(
-        database: WatcherDatabase = WatcherDatabase.open(),
-        input: InputStream = System.`in`,
-        output: OutputStream = System.out,
-    ) {
-        database.use {
-            val server = DaemonitorMcpServer(it)
-            McpMessageStream(input, output).serve(server)
-        }
-    }
-}
-
-internal class McpMessageStream(
+class McpMessageStream(
     input: InputStream,
     output: OutputStream,
 ) {

--- a/src/test/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryServiceTest.kt
@@ -1,0 +1,128 @@
+package io.github.cdsap.daemonitor.application
+
+import io.github.cdsap.daemonitor.domain.model.Build
+import io.github.cdsap.daemonitor.domain.model.FinalStatus
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.domain.model.Source
+import io.github.cdsap.daemonitor.store.WatcherDatabase
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DefaultDaemonitorQueryServiceTest {
+
+    @Test
+    fun `searchHistory delegates to retained builds`(@TempDir tmp: Path) {
+        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        db.insertBuild(build("old", 1_000, project = "/repo/a"))
+        db.insertBuild(build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED))
+        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+
+        val builds = queries.searchHistory("target", limit = 50)
+
+        assertEquals(listOf("match"), builds.map { it.buildId })
+        assertEquals(FinalStatus.FAILED, builds.single().finalStatus)
+    }
+
+    @Test
+    fun `buildsForProcess matches pid builds and samples`(@TempDir tmp: Path) {
+        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        db.insertBuild(build("b1", 3_000, pid = 42, project = "/repo/target"))
+        db.insertSample(
+            GradleProcess(
+                pid = 42,
+                parentPid = 7,
+                type = ProcessType.GRADLE_DAEMON,
+                commandLine = "java GradleDaemon",
+                workingDirectory = "/repo/target",
+                projectPath = "/repo/target",
+                cpuPercent = 12.0,
+                rssMemoryMb = 512,
+                maxHeapMb = 2048,
+                minHeapMb = null,
+                gc = "G1",
+                startTimeMs = 1_000,
+                status = "RUNNING",
+            ),
+            timestampMs = 3_100,
+        )
+        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+
+        val result = queries.buildsForProcess("42", limit = 50)
+
+        assertEquals("42", result.process)
+        assertEquals(listOf("b1"), result.matchedBuilds.map { it.buildId })
+        assertEquals(listOf(42L), result.matchedProcessSamples.map { it.pid })
+    }
+
+    @Test
+    fun `buildsForProcess text match filters recent samples`(@TempDir tmp: Path) {
+        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        db.insertBuild(build("keep", 4_000, project = "/repo/target"))
+        db.insertSample(sample(pid = 10, project = "/repo/target"), timestampMs = 4_100)
+        db.insertSample(sample(pid = 11, project = "/repo/other"), timestampMs = 4_200)
+        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+
+        val result = queries.buildsForProcess("target", limit = 50)
+
+        assertEquals(listOf("keep"), result.matchedBuilds.map { it.buildId })
+        assertEquals(listOf(10L), result.matchedProcessSamples.map { it.pid })
+    }
+
+    @Test
+    fun `currentProcesses uses process source`(@TempDir tmp: Path) {
+        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        val process = sample(pid = 99, project = "/repo", type = ProcessType.KOTLIN_DAEMON)
+        val queries = DefaultDaemonitorQueryService(db, ProcessSource { listOf(process) })
+
+        assertEquals(listOf(99L), queries.currentProcesses().map { it.pid })
+    }
+
+    private fun build(
+        id: String,
+        startMs: Long,
+        pid: Long = 1,
+        project: String = "/repo",
+        status: FinalStatus = FinalStatus.SUCCESS,
+    ) = Build(
+        buildId = id,
+        daemonPid = pid,
+        daemonIdentity = "uid-$pid",
+        commandLine = "gradlew build",
+        workingDirectory = project,
+        projectPath = project,
+        startTimeMs = startMs,
+        endTimeMs = startMs + 1000,
+        durationSeconds = 1.0,
+        peakMemoryMb = 700,
+        avgMemoryMb = 600,
+        peakCpuPercent = 50.0,
+        inferredSource = Source.TERMINAL,
+        finalStatus = status,
+        logSnippet = "BUILD ${if (status == FinalStatus.SUCCESS) "SUCCESSFUL" else "FAILED"}",
+        agent = null,
+        agentProvider = null,
+    )
+
+    private fun sample(
+        pid: Long,
+        project: String,
+        type: ProcessType = ProcessType.GRADLE_DAEMON,
+    ) = GradleProcess(
+        pid = pid,
+        parentPid = 1,
+        type = type,
+        commandLine = "java $type",
+        workingDirectory = project,
+        projectPath = project,
+        cpuPercent = 1.0,
+        rssMemoryMb = 256,
+        maxHeapMb = 1024,
+        minHeapMb = null,
+        gc = null,
+        startTimeMs = 1,
+        status = "RUNNING",
+    )
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
@@ -1,5 +1,7 @@
 package io.github.cdsap.daemonitor.mcp
 
+import io.github.cdsap.daemonitor.application.DefaultDaemonitorQueryService
+import io.github.cdsap.daemonitor.application.ProcessSource
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import org.junit.jupiter.api.io.TempDir
 import java.net.URI
@@ -16,7 +18,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `post request returns mcp json response`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, mcpServer(db))
         try {
             val response = post(
                 endpoint = server.endpoint,
@@ -36,7 +38,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `post request requires token`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, mcpServer(db))
         try {
             val response = request(server.endpoint, token = null, method = "POST")
 
@@ -50,7 +52,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `browser origins must be loopback`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, mcpServer(db))
         try {
             val response = request(
                 endpoint = server.endpoint,
@@ -69,7 +71,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `notifications return accepted without body`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, mcpServer(db))
         try {
             val response = post(
                 endpoint = server.endpoint,
@@ -88,7 +90,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `get request is rejected because sse is not supported`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, mcpServer(db))
         try {
             val response = request(server.endpoint, token = TOKEN, method = "GET")
 
@@ -99,6 +101,9 @@ class DaemonitorMcpHttpServerTest {
             db.close()
         }
     }
+
+    private fun mcpServer(db: WatcherDatabase): DaemonitorMcpServer =
+        DaemonitorMcpServer(DefaultDaemonitorQueryService(db, ProcessSource { emptyList() }))
 
     private fun post(endpoint: String, token: String, body: String): HttpResponse<String> =
         request(endpoint, token = token, method = "POST", body = body)

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
@@ -1,5 +1,7 @@
 package io.github.cdsap.daemonitor.mcp
 
+import io.github.cdsap.daemonitor.application.DefaultDaemonitorQueryService
+import io.github.cdsap.daemonitor.application.ProcessSource
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
@@ -36,7 +38,7 @@ class DaemonitorMcpServerTest {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
         db.insertBuild(build("old", 1_000, project = "/repo/a", status = FinalStatus.SUCCESS))
         db.insertBuild(build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED))
-        val server = DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() })
+        val server = DaemonitorMcpServer(queryService(db, emptyList()))
 
         val payload = server.callTool(
             "daemonitor_search_history",
@@ -70,7 +72,7 @@ class DaemonitorMcpServerTest {
             ),
             timestampMs = 3_100,
         )
-        val server = DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() })
+        val server = DaemonitorMcpServer(queryService(db, emptyList()))
 
         val payload = server.callTool(
             "daemonitor_builds_for_process",
@@ -119,9 +121,16 @@ class DaemonitorMcpServerTest {
         currentProcesses: List<GradleProcess> = emptyList(),
     ): DaemonitorMcpServer =
         DaemonitorMcpServer(
-            database = WatcherDatabase.open(tmp.resolve("watcher.db")),
-            currentProcessesProvider = { currentProcesses },
+            queryService(WatcherDatabase.open(tmp.resolve("watcher.db")), currentProcesses),
         )
+
+    private fun queryService(
+        database: WatcherDatabase,
+        currentProcesses: List<GradleProcess>,
+    ) = DefaultDaemonitorQueryService(
+        database = database,
+        processSource = ProcessSource { currentProcesses },
+    )
 
     private fun DaemonitorMcpServer.request(method: String, params: JsonObject = jsonObject()): JsonObject =
         handle(


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#95: Add an application query service for MCP

Fixes #95

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`