### PR TITLE
fix: introduce persistence repository ports

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/HeadlessMain.kt
@@ -3,6 +3,8 @@
 package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.config.MonitoringConfig
+import io.github.cdsap.daemonitor.persistence.RetentionRepository
+import io.github.cdsap.daemonitor.persistence.SettingsRepository
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import kotlinx.coroutines.CancellationException
@@ -32,8 +34,10 @@ internal object HeadlessLauncher {
 
         HeadlessMacMode.configure()
         val database = WatcherDatabase.open()
+        val retention: RetentionRepository = database
+        val settings: SettingsRepository = SettingsStore()
         val runtime = WatcherRuntime.create(database)
-        val retentionDays = SettingsStore().load().retentionDays
+        val retentionDays = settings.load().retentionDays
         val pollingThread = Thread.currentThread()
         val running = AtomicBoolean(true)
         val cleanupFinished = CountDownLatch(1)
@@ -59,7 +63,7 @@ internal object HeadlessLauncher {
         )
 
         return try {
-            database.purgeOlderThan(System.currentTimeMillis(), retentionDays)
+            retention.purgeOlderThan(System.currentTimeMillis(), retentionDays)
             Runtime.getRuntime().addShutdownHook(shutdownHook)
             output.println("Daemonitor headless collector started")
             runBlocking {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -6,6 +6,8 @@ import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.domain.BuildAggregator
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 
 /** UI-independent collection and persistence runtime shared by desktop and headless launchers. */
@@ -13,7 +15,8 @@ class WatcherRuntime(
     private val collector: ProcessCollector = ProcessCollector(),
     private val logWatcher: DaemonLogWatcher = DaemonLogWatcher(),
     private val aggregator: BuildAggregator,
-    private val database: WatcherDatabase,
+    private val builds: BuildRepository,
+    private val processSamples: ProcessSampleRepository,
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
     private var knownDaemonPids = emptySet<Long>()
@@ -27,7 +30,7 @@ class WatcherRuntime(
     fun pollOnce(): PollResult {
         val now = clock()
         val processes = collector.poll()
-        processes.forEach { database.insertSample(it, now) }
+        processes.forEach { processSamples.save(it, now) }
 
         val logs = logWatcher.discover()
         return PollResult(
@@ -47,13 +50,13 @@ class WatcherRuntime(
             val lines = logWatcher.readNewLines(log.path)
             if (lines.isNotEmpty()) {
                 lines.flatMap { aggregator.onLogLine(log.pid, it.text, it.event) }.forEach {
-                    database.insertBuild(it)
+                    builds.save(it)
                     inserted = true
                 }
             }
             if (log.pid !in activeDaemonPids) {
                 aggregator.onDaemonGone(log.pid)?.let {
-                    database.insertBuild(it)
+                    builds.save(it)
                     inserted = true
                 }
             }
@@ -61,7 +64,7 @@ class WatcherRuntime(
 
         (knownDaemonPids - activeDaemonPids).forEach { gonePid ->
             aggregator.onDaemonGone(gonePid)?.let {
-                database.insertBuild(it)
+                builds.save(it)
                 inserted = true
             }
         }
@@ -75,10 +78,11 @@ class WatcherRuntime(
     companion object {
         fun create(database: WatcherDatabase): WatcherRuntime = WatcherRuntime(
             aggregator = BuildAggregator(
-                sampleProvider = database::samplesInWindow,
+                sampleProvider = database::samples,
                 ambientEnvNames = System.getenv().keys.toSet(),
             ),
-            database = database,
+            builds = database,
+            processSamples = database,
         )
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -1,8 +1,12 @@
 package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.config.MonitoringConfig
-import io.github.cdsap.daemonitor.store.AppearancePreference
-import io.github.cdsap.daemonitor.store.Settings
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
+import io.github.cdsap.daemonitor.persistence.RetentionRepository
+import io.github.cdsap.daemonitor.persistence.Settings
+import io.github.cdsap.daemonitor.persistence.SettingsRepository
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.mcp.DaemonitorMcpHttpServer
@@ -29,8 +33,10 @@ import kotlinx.coroutines.withContext
 /** Desktop adapter that runs [WatcherRuntime] on [Dispatchers.IO] and projects results into UI state. */
 class WatcherService(
     private val runtime: WatcherRuntime,
-    private val database: WatcherDatabase,
-    private val settingsStore: SettingsStore = SettingsStore(),
+    private val builds: BuildRepository,
+    private val processSamples: ProcessSampleRepository,
+    private val retention: RetentionRepository,
+    private val settingsStore: SettingsRepository = SettingsStore(),
     private val clock: () -> Long = System::currentTimeMillis,
     private val pollAction: suspend () -> WatcherRuntime.PollResult = { runtime.pollOnce() },
     private val updateChecker: suspend () -> UpdateCheckResult = {
@@ -73,7 +79,7 @@ class WatcherService(
         serviceScope = boundScope
         settingsViewModel.checkForUpdates()
         if (settingsViewModel.state.value.mcpEnabled) startMcpServer(boundScope)
-        database.purgeOlderThan(clock(), retentionDays)
+        retention.purgeOlderThan(clock(), retentionDays)
         // Load whatever history already exists, then keep it current from the poll loop.
         boundScope.launch(ioDispatcher) { refreshHistory() }
         boundScope.launch(ioDispatcher) {
@@ -86,7 +92,7 @@ class WatcherService(
 
     /**
      * Cancels background poll/history work and waits for it to finish.
-     * Call this before closing [database] so temp-dir cleanup cannot race in-flight SQLite access.
+     * Call this before closing the database so temp-dir cleanup cannot race in-flight SQLite access.
      */
     suspend fun stop() {
         mcpHttpServer?.close()
@@ -104,7 +110,7 @@ class WatcherService(
         saveSettings()
         val scope = serviceScope ?: return
         scope.launch(ioDispatcher) {
-            database.purgeOlderThan(clock(), days)
+            retention.purgeOlderThan(clock(), days)
             refreshHistory()
         }
     }
@@ -140,7 +146,7 @@ class WatcherService(
                 DaemonitorMcpHttpServer.start(
                     port = state.mcpPort,
                     token = state.mcpToken,
-                    server = DaemonitorMcpServer(database),
+                    server = DaemonitorMcpServer(builds, processSamples),
                 )
             }.onSuccess { server ->
                 if (!settingsViewModel.state.value.mcpEnabled) {
@@ -180,10 +186,10 @@ class WatcherService(
      *  Historical tab updates within one poll instead of waiting on `asFlow` notifications that did
      *  not fire reliably with the JDBC SQLite driver. */
     private suspend fun refreshHistory() {
-        val builds = database.recentBuilds()
-        val projects = database.distinctProjects()
+        val recentBuilds = builds.recent()
+        val projects = builds.distinctProjects()
         withContext(uiDispatcher) {
-            historyViewModel.onBuilds(builds)
+            historyViewModel.onBuilds(recentBuilds)
             historyViewModel.onProjects(projects)
         }
     }
@@ -230,7 +236,9 @@ class WatcherService(
         fun create(database: WatcherDatabase = WatcherDatabase.open()): WatcherService =
             WatcherService(
                 runtime = WatcherRuntime.create(database),
-                database = database,
+                builds = database,
+                processSamples = database,
+                retention = database,
             )
     }
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServer.kt
@@ -4,7 +4,9 @@ import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.collect.ProcessCollector
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
-import io.github.cdsap.daemonitor.store.ProcessSample
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
@@ -13,7 +15,8 @@ import java.io.OutputStream
 import java.nio.charset.StandardCharsets
 
 class DaemonitorMcpServer(
-    private val database: WatcherDatabase,
+    private val builds: BuildRepository,
+    private val processSamples: ProcessSampleRepository,
     private val currentProcessesProvider: () -> List<GradleProcess> = ProcessCollector()::poll,
 ) {
     internal fun handle(request: JsonObject): JsonObject? {
@@ -166,15 +169,15 @@ class DaemonitorMcpServer(
 
         val limit = arguments.long("limit").coerceLimit()
         val pid = process.toLongOrNull()
-        val builds = if (pid != null) {
-            database.buildsForDaemonPid(pid, limit)
+        val matchedBuilds = if (pid != null) {
+            builds.findByDaemon(pid, limit)
         } else {
-            database.searchBuilds(process, limit)
+            builds.search(process, limit)
         }
         val samples = if (pid != null) {
-            database.processSamplesForPid(pid, limit)
+            processSamples.findByPid(pid, limit)
         } else {
-            database.recentProcessSamples(200).filter { sample ->
+            processSamples.recentSamples(200).filter { sample ->
                 sample.commandLine.contains(process, ignoreCase = true) ||
                     sample.workingDirectory?.contains(process, ignoreCase = true) == true ||
                     sample.projectPath?.contains(process, ignoreCase = true) == true ||
@@ -184,7 +187,7 @@ class DaemonitorMcpServer(
 
         return jsonObject(
             "process" to JsonString(process),
-            "matchedBuilds" to JsonArray(builds.map { it.toJson() }),
+            "matchedBuilds" to JsonArray(matchedBuilds.map { it.toJson() }),
             "matchedProcessSamples" to JsonArray(samples.map { it.toJson() }),
         )
     }
@@ -192,10 +195,10 @@ class DaemonitorMcpServer(
     private fun searchHistory(arguments: JsonObject): JsonObject {
         val query = arguments.string("query").orEmpty()
         val limit = arguments.long("limit").coerceLimit()
-        val builds = database.searchBuilds(query, limit)
+        val matchedBuilds = builds.search(query, limit)
         return jsonObject(
             "query" to JsonString(query),
-            "builds" to JsonArray(builds.map { it.toJson() }),
+            "builds" to JsonArray(matchedBuilds.map { it.toJson() }),
         )
     }
 
@@ -286,7 +289,7 @@ object DaemonitorMcpStdio {
         output: OutputStream = System.out,
     ) {
         database.use {
-            val server = DaemonitorMcpServer(it)
+            val server = DaemonitorMcpServer(it, it)
             McpMessageStream(input, output).serve(server)
         }
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/BuildRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/BuildRepository.kt
@@ -1,0 +1,16 @@
+package io.github.cdsap.daemonitor.persistence
+
+import io.github.cdsap.daemonitor.domain.model.Build
+
+/** Port for build history persistence and queries. */
+interface BuildRepository {
+    fun save(build: Build)
+    fun recent(): List<Build>
+    fun search(query: String, limit: Long = DEFAULT_QUERY_LIMIT): List<Build>
+    fun findByDaemon(pid: Long, limit: Long = DEFAULT_QUERY_LIMIT): List<Build>
+    fun distinctProjects(): List<String>
+
+    companion object {
+        const val DEFAULT_QUERY_LIMIT = 50L
+    }
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSample.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSample.kt
@@ -1,0 +1,18 @@
+package io.github.cdsap.daemonitor.persistence
+
+import io.github.cdsap.daemonitor.domain.model.ProcessType
+
+/** A persisted process snapshot used by history and MCP queries. */
+data class ProcessSample(
+    val timestampMs: Long,
+    val pid: Long,
+    val parentPid: Long,
+    val processType: ProcessType,
+    val commandLine: String,
+    val workingDirectory: String?,
+    val projectPath: String?,
+    val cpuPercent: Double?,
+    val rssMemoryMb: Long,
+    val maxHeapMb: Long?,
+    val status: String,
+)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSampleRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSampleRepository.kt
@@ -1,0 +1,17 @@
+package io.github.cdsap.daemonitor.persistence
+
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+
+/** Port for process-sample persistence and queries. */
+interface ProcessSampleRepository {
+    fun save(sample: GradleProcess, timestampMs: Long)
+
+    /**
+     * RSS + CPU samples for a PID within `[fromMs, toMs]` — used by the build aggregator.
+     * Each pair is `(rssMemoryMb, cpuPercent)`.
+     */
+    fun samples(pid: Long, fromMs: Long, toMs: Long): List<Pair<Long, Double?>>
+
+    fun recentSamples(limit: Long = BuildRepository.DEFAULT_QUERY_LIMIT): List<ProcessSample>
+    fun findByPid(pid: Long, limit: Long = BuildRepository.DEFAULT_QUERY_LIMIT): List<ProcessSample>
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/RetentionRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/RetentionRepository.kt
@@ -1,0 +1,11 @@
+package io.github.cdsap.daemonitor.persistence
+
+import io.github.cdsap.daemonitor.config.RetentionPolicy
+
+/** Port for purging persisted samples and builds outside the retention window. */
+interface RetentionRepository {
+    fun purgeOlderThan(
+        nowMs: Long,
+        retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays,
+    )
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/Settings.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/Settings.kt
@@ -1,0 +1,15 @@
+package io.github.cdsap.daemonitor.persistence
+
+import io.github.cdsap.daemonitor.Defaults
+import io.github.cdsap.daemonitor.config.RetentionPolicy
+
+/** User-configurable settings (KTD-9 deferred config, now partially realized). */
+data class Settings(
+    val retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays,
+    val appearance: AppearancePreference = AppearancePreference.SYSTEM,
+    val mcpEnabled: Boolean = false,
+    val mcpPort: Int = Defaults.DEFAULT_MCP_PORT,
+    val mcpToken: String = "",
+)
+
+enum class AppearancePreference { SYSTEM, LIGHT, DARK }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/SettingsRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/SettingsRepository.kt
@@ -1,0 +1,7 @@
+package io.github.cdsap.daemonitor.persistence
+
+/** Port for loading and saving user-configurable application settings. */
+interface SettingsRepository {
+    fun load(): Settings
+    fun save(settings: Settings)
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/SettingsStore.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/SettingsStore.kt
@@ -2,6 +2,9 @@ package io.github.cdsap.daemonitor.store
 
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.config.RetentionPolicy
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.Settings
+import io.github.cdsap.daemonitor.persistence.SettingsRepository
 import io.github.cdsap.daemonitor.platform.AppDirectories
 import java.nio.file.Files
 import java.nio.file.Path
@@ -12,26 +15,15 @@ import kotlin.io.path.exists
 import kotlin.io.path.inputStream
 import kotlin.io.path.outputStream
 
-/** User-configurable settings (KTD-9 deferred config, now partially realized). */
-data class Settings(
-    val retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays,
-    val appearance: AppearancePreference = AppearancePreference.SYSTEM,
-    val mcpEnabled: Boolean = false,
-    val mcpPort: Int = Defaults.DEFAULT_MCP_PORT,
-    val mcpToken: String = "",
-)
-
-enum class AppearancePreference { SYSTEM, LIGHT, DARK }
-
 /**
  * Tiny properties-file settings store kept alongside the database. A full config table would be
  * over-built for a single scalar; a properties file is dependency-free, human-readable, and avoids
  * a schema migration. Reads are defensive — a missing/corrupt file or out-of-range value falls back
  * to the default rather than failing the app.
  */
-class SettingsStore(private val path: Path = AppDirectories.system.settingsPath) {
+class SettingsStore(private val path: Path = AppDirectories.system.settingsPath) : SettingsRepository {
 
-    fun load(): Settings {
+    override fun load(): Settings {
         if (!path.exists()) return Settings(mcpToken = newMcpToken())
         val props = Properties()
         runCatching { path.inputStream().use { props.load(it) } }
@@ -54,7 +46,7 @@ class SettingsStore(private val path: Path = AppDirectories.system.settingsPath)
         )
     }
 
-    fun save(settings: Settings) {
+    override fun save(settings: Settings) {
         runCatching {
             Files.createDirectories(path.parent)
             val mcpToken = settings.mcpToken.ifBlank { newMcpToken() }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
@@ -4,13 +4,16 @@ import app.cash.sqldelight.coroutines.asFlow
 import app.cash.sqldelight.coroutines.mapToList
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import app.cash.sqldelight.db.SqlDriver
-import io.github.cdsap.daemonitor.config.RetentionPolicy
 import io.github.cdsap.daemonitor.platform.AppDirectories
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
 import io.github.cdsap.daemonitor.domain.model.Source
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
+import io.github.cdsap.daemonitor.persistence.RetentionRepository
 import io.github.cdsap.daemonitor.store.db.Process_samples
 import io.github.cdsap.daemonitor.store.db.WatcherDb
 import kotlinx.coroutines.CoroutineDispatcher
@@ -30,75 +33,78 @@ import kotlin.io.path.exists
  *
  * Redaction invariant (KTD-7): callers pass only pre-redacted command lines / log snippets;
  * the collector (U2), log watcher (U3), and aggregator (U5) all redact upstream.
+ *
+ * Implements repository ports so application code can depend on interfaces rather than this
+ * concrete SQLite type.
  */
 class WatcherDatabase private constructor(
     private val db: WatcherDb,
     private val driver: SqlDriver,
     private val ioDispatcher: CoroutineDispatcher,
-) : AutoCloseable {
+) : BuildRepository, ProcessSampleRepository, RetentionRepository, AutoCloseable {
 
     override fun close() = driver.close()
 
-    fun insertSample(p: GradleProcess, timestampMs: Long) {
+    override fun save(sample: GradleProcess, timestampMs: Long) {
         db.watcherQueries.insertSample(
             timestamp = timestampMs,
-            pid = p.pid,
-            parent_pid = p.parentPid,
-            process_type = p.type.name,
-            command_line = p.commandLine,
-            working_directory = p.workingDirectory,
-            project_path = p.projectPath,
-            cpu_percent = p.cpuPercent,
-            rss_memory_mb = p.rssMemoryMb,
-            max_heap_mb = p.maxHeapMb,
-            status = p.status,
+            pid = sample.pid,
+            parent_pid = sample.parentPid,
+            process_type = sample.type.name,
+            command_line = sample.commandLine,
+            working_directory = sample.workingDirectory,
+            project_path = sample.projectPath,
+            cpu_percent = sample.cpuPercent,
+            rss_memory_mb = sample.rssMemoryMb,
+            max_heap_mb = sample.maxHeapMb,
+            status = sample.status,
         )
     }
 
-    fun insertBuild(b: Build) {
+    override fun save(build: Build) {
         db.watcherQueries.insertBuild(
-            build_id = b.buildId,
-            daemon_pid = b.daemonPid,
-            daemon_identity = b.daemonIdentity,
-            command_line = b.commandLine,
-            working_directory = b.workingDirectory,
-            project_path = b.projectPath,
-            start_time = b.startTimeMs,
-            end_time = b.endTimeMs,
-            duration_seconds = b.durationSeconds,
-            peak_memory_mb = b.peakMemoryMb,
-            avg_memory_mb = b.avgMemoryMb,
-            peak_cpu_percent = b.peakCpuPercent,
-            inferred_source = b.inferredSource.name,
-            final_status = b.finalStatus.name,
-            log_snippet = b.logSnippet,
-            agent = b.agent,
-            agent_provider = b.agentProvider,
+            build_id = build.buildId,
+            daemon_pid = build.daemonPid,
+            daemon_identity = build.daemonIdentity,
+            command_line = build.commandLine,
+            working_directory = build.workingDirectory,
+            project_path = build.projectPath,
+            start_time = build.startTimeMs,
+            end_time = build.endTimeMs,
+            duration_seconds = build.durationSeconds,
+            peak_memory_mb = build.peakMemoryMb,
+            avg_memory_mb = build.avgMemoryMb,
+            peak_cpu_percent = build.peakCpuPercent,
+            inferred_source = build.inferredSource.name,
+            final_status = build.finalStatus.name,
+            log_snippet = build.logSnippet,
+            agent = build.agent,
+            agent_provider = build.agentProvider,
         )
     }
 
-    /** RSS + CPU samples for a PID within [startMs, endMs] — used by the aggregator (U5). */
-    fun samplesInWindow(pid: Long, startMs: Long, endMs: Long): List<Pair<Long, Double?>> =
-        db.watcherQueries.samplesInWindow(pid, startMs, endMs)
+    /** RSS + CPU samples for a PID within [fromMs, toMs] — used by the aggregator (U5). */
+    override fun samples(pid: Long, fromMs: Long, toMs: Long): List<Pair<Long, Double?>> =
+        db.watcherQueries.samplesInWindow(pid, fromMs, toMs)
             .executeAsList()
             .map { it.rss_memory_mb to it.cpu_percent }
 
-    fun processSampleCount(type: ProcessType): Long =
+    fun countByType(type: ProcessType): Long =
         db.watcherQueries.countProcessSamplesByType(type.name).executeAsOne()
 
     /** One-shot snapshot of all retained builds, newest first. Drives the explicit History refresh
      *  the poll loop triggers after inserting builds (reactive `asFlow` notifications proved
      *  unreliable for live updates with the JDBC SQLite driver). */
-    fun recentBuilds(): List<Build> =
+    override fun recent(): List<Build> =
         db.watcherQueries.recentBuilds().executeAsList().map { it.toDomain() }
 
-    fun buildsForDaemonPid(pid: Long, limit: Long = DEFAULT_QUERY_LIMIT): List<Build> =
+    override fun findByDaemon(pid: Long, limit: Long): List<Build> =
         db.watcherQueries.buildsForDaemonPid(pid, limit.coerceQueryLimit()).executeAsList()
             .map { it.toDomain() }
 
-    fun searchBuilds(query: String, limit: Long = DEFAULT_QUERY_LIMIT): List<Build> {
+    override fun search(query: String, limit: Long): List<Build> {
         val sanitizedQuery = query.trim()
-        if (sanitizedQuery.isEmpty()) return recentBuilds().take(limit.coerceQueryLimit().toInt())
+        if (sanitizedQuery.isEmpty()) return recent().take(limit.coerceQueryLimit().toInt())
         return db.watcherQueries.searchBuilds(
             sanitizedQuery,
             sanitizedQuery,
@@ -112,16 +118,16 @@ class WatcherDatabase private constructor(
         ).executeAsList().map { it.toDomain() }
     }
 
-    fun recentProcessSamples(limit: Long = DEFAULT_QUERY_LIMIT): List<ProcessSample> =
+    override fun recentSamples(limit: Long): List<ProcessSample> =
         db.watcherQueries.recentProcessSamples(limit.coerceQueryLimit()).executeAsList()
             .map { it.toDomain() }
 
-    fun processSamplesForPid(pid: Long, limit: Long = DEFAULT_QUERY_LIMIT): List<ProcessSample> =
+    override fun findByPid(pid: Long, limit: Long): List<ProcessSample> =
         db.watcherQueries.processSamplesForPid(pid, limit.coerceQueryLimit()).executeAsList()
             .map { it.toDomain() }
 
     /** One-shot snapshot of distinct project paths for the History filter dropdown. */
-    fun distinctProjects(): List<String> =
+    override fun distinctProjects(): List<String> =
         db.watcherQueries.distinctProjects().executeAsList()
 
     fun buildsFlow(): Flow<List<Build>> =
@@ -138,7 +144,7 @@ class WatcherDatabase private constructor(
         db.watcherQueries.distinctProjects().asFlow().mapToList(ioDispatcher)
 
     /** Delete samples and builds older than [retentionDays] before [nowMs] (KTD-5). */
-    fun purgeOlderThan(nowMs: Long, retentionDays: Long = RetentionPolicy.DEFAULT.defaultDays) {
+    override fun purgeOlderThan(nowMs: Long, retentionDays: Long) {
         val cutoff = nowMs - retentionDays * 24 * 60 * 60 * 1000
         db.watcherQueries.purgeSamplesOlderThan(cutoff)
         db.watcherQueries.purgeBuildsOlderThan(cutoff)
@@ -173,7 +179,6 @@ class WatcherDatabase private constructor(
             ).forEach { sql -> runCatching { driver.execute(null, sql, 0) } }
         }
 
-        private const val DEFAULT_QUERY_LIMIT = 50L
         private const val MAX_QUERY_LIMIT = 200L
 
         private fun Long.coerceQueryLimit(): Long = coerceIn(1, MAX_QUERY_LIMIT)
@@ -226,17 +231,3 @@ class WatcherDatabase private constructor(
         )
     }
 }
-
-data class ProcessSample(
-    val timestampMs: Long,
-    val pid: Long,
-    val parentPid: Long,
-    val processType: ProcessType,
-    val commandLine: String,
-    val workingDirectory: String?,
-    val projectPath: String?,
-    val cpuPercent: Double?,
-    val rssMemoryMb: Long,
-    val maxHeapMb: Long?,
-    val status: String,
-)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Theme.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/common/Theme.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 
 /** Single 4-pt spacing scale so every screen uses the same rhythm (removes the "scattered" feel). */
 object Space {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.config.RetentionPolicy
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.ui.common.SectionCard
 import io.github.cdsap.daemonitor.ui.common.ScreenHeader
 import io.github.cdsap.daemonitor.ui.common.Radius

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModel.kt
@@ -3,7 +3,7 @@ package io.github.cdsap.daemonitor.ui.settings
 import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.config.RetentionPolicy
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.update.DesktopUpdateApplier
 import io.github.cdsap.daemonitor.update.DesktopUpdateInstaller
 import io.github.cdsap.daemonitor.update.GitHubReleaseUpdateSource

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherRuntimeTest.kt
@@ -28,8 +28,9 @@ class WatcherRuntimeTest {
         WatcherDatabase.open(tmp.resolve("watcher.db")).use { database ->
             val runtime = WatcherRuntime(
                 logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle")),
-                aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
-                database = database,
+                aggregator = BuildAggregator(sampleProvider = database::samples),
+                builds = database,
+                processSamples = database,
             )
 
             runtime.pollOnce() // Establish the incremental-read offset.
@@ -48,7 +49,7 @@ class WatcherRuntimeTest {
 
             assertTrue(runtime.pollOnce().buildsChanged)
 
-            val build = database.recentBuilds().single()
+            val build = database.recent().single()
             val snippet = assertNotNull(build.logSnippet)
             assertTrue(snippet.contains("-Ptoken=***"))
             assertFalse(snippet.contains("window-secret"))
@@ -76,14 +77,15 @@ class WatcherRuntimeTest {
             val logWatcher = DaemonLogWatcher(gradleUserHome = tmp.resolve("gradle"))
             val runtime = WatcherRuntime(
                 logWatcher = logWatcher,
-                aggregator = BuildAggregator(sampleProvider = database::samplesInWindow),
-                database = database,
+                aggregator = BuildAggregator(sampleProvider = database::samples),
+                builds = database,
+                processSamples = database,
             )
 
             val changed = runtime.processForBuilds(logWatcher.discover(), activeDaemonPids = emptySet())
 
             assertTrue(changed)
-            val build = database.recentBuilds().single()
+            val build = database.recent().single()
             assertEquals("build-96", build.buildId)
             assertEquals(FinalStatus.SUCCESS, build.finalStatus)
         }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -152,7 +152,9 @@ class WatcherServiceTest {
         pollAction: suspend () -> WatcherRuntime.PollResult,
     ) = WatcherService(
         runtime = WatcherRuntime.create(database),
-        database = database,
+        builds = database,
+        processSamples = database,
+        retention = database,
         settingsStore = SettingsStore(tmp.resolve("settings.properties")),
         clock = clock,
         pollAction = pollAction,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
@@ -16,7 +16,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `post request returns mcp json response`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() }))
         try {
             val response = post(
                 endpoint = server.endpoint,
@@ -36,7 +36,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `post request requires token`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() }))
         try {
             val response = request(server.endpoint, token = null, method = "POST")
 
@@ -50,7 +50,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `browser origins must be loopback`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() }))
         try {
             val response = request(
                 endpoint = server.endpoint,
@@ -69,7 +69,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `notifications return accepted without body`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() }))
         try {
             val response = post(
                 endpoint = server.endpoint,
@@ -88,7 +88,7 @@ class DaemonitorMcpHttpServerTest {
     @Test
     fun `get request is rejected because sse is not supported`(@TempDir tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() }))
+        val server = DaemonitorMcpHttpServer.start(0, TOKEN, DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() }))
         try {
             val response = request(server.endpoint, token = TOKEN, method = "GET")
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
@@ -34,9 +34,9 @@ class DaemonitorMcpServerTest {
     @Test
     fun `search history returns retained builds from sql`(@TempDirArg tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("old", 1_000, project = "/repo/a", status = FinalStatus.SUCCESS))
-        db.insertBuild(build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED))
-        val server = DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() })
+        db.save(build("old", 1_000, project = "/repo/a", status = FinalStatus.SUCCESS))
+        db.save(build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED))
+        val server = DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() })
 
         val payload = server.callTool(
             "daemonitor_search_history",
@@ -51,8 +51,8 @@ class DaemonitorMcpServerTest {
     @Test
     fun `builds for process matches daemon pid and samples`(@TempDirArg tmp: Path) {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("b1", 3_000, pid = 42, project = "/repo/target"))
-        db.insertSample(
+        db.save(build("b1", 3_000, pid = 42, project = "/repo/target"))
+        db.save(
             GradleProcess(
                 pid = 42,
                 parentPid = 7,
@@ -70,7 +70,7 @@ class DaemonitorMcpServerTest {
             ),
             timestampMs = 3_100,
         )
-        val server = DaemonitorMcpServer(db, currentProcessesProvider = { emptyList() })
+        val server = DaemonitorMcpServer(db, db, currentProcessesProvider = { emptyList() })
 
         val payload = server.callTool(
             "daemonitor_builds_for_process",
@@ -117,11 +117,14 @@ class DaemonitorMcpServerTest {
     private fun server(
         tmp: Path,
         currentProcesses: List<GradleProcess> = emptyList(),
-    ): DaemonitorMcpServer =
-        DaemonitorMcpServer(
-            database = WatcherDatabase.open(tmp.resolve("watcher.db")),
+    ): DaemonitorMcpServer {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        return DaemonitorMcpServer(
+            builds = database,
+            processSamples = database,
             currentProcessesProvider = { currentProcesses },
         )
+    }
 
     private fun DaemonitorMcpServer.request(method: String, params: JsonObject = jsonObject()): JsonObject =
         handle(

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/SettingsStoreTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/SettingsStoreTest.kt
@@ -2,11 +2,15 @@ package io.github.cdsap.daemonitor.store
 
 import io.github.cdsap.daemonitor.Defaults
 import io.github.cdsap.daemonitor.config.RetentionPolicy
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.Settings
+import io.github.cdsap.daemonitor.persistence.SettingsRepository
 import org.junit.jupiter.api.io.TempDir
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertIs
 
 class SettingsStoreTest {
 
@@ -51,5 +55,14 @@ class SettingsStoreTest {
         val path = tmp.resolve("settings.properties")
         java.nio.file.Files.writeString(path, "retentionDays=30\nappearance=sepia\n")
         assertEquals(AppearancePreference.SYSTEM, SettingsStore(path).load().appearance)
+    }
+
+    @Test
+    fun `SettingsStore implements SettingsRepository`(@TempDir tmp: Path) {
+        val repository: SettingsRepository = SettingsStore(tmp.resolve("settings.properties"))
+        assertIs<SettingsRepository>(repository)
+        repository.save(Settings(retentionDays = 14, appearance = AppearancePreference.LIGHT))
+        assertEquals(14, repository.load().retentionDays)
+        assertEquals(AppearancePreference.LIGHT, repository.load().appearance)
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
@@ -5,6 +5,9 @@ import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
 import io.github.cdsap.daemonitor.domain.model.Source
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
+import io.github.cdsap.daemonitor.persistence.RetentionRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import java.nio.file.Files
@@ -40,7 +43,7 @@ class WatcherDatabaseTest {
     @Test
     fun `build round-trips through the database`(@TempDirArg tmp: Path) = runTest {
         val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("b1", 10_000))
+        db.save(build("b1", 10_000))
         val rows = db.buildsFlow().first()
         assertEquals(1, rows.size)
         assertEquals(FinalStatus.SUCCESS, rows[0].finalStatus)
@@ -59,8 +62,8 @@ class WatcherDatabaseTest {
             cpuPercent = null, rssMemoryMb = 300, maxHeapMb = null, minHeapMb = null,
             gc = null, startTimeMs = 1, status = "RUNNING",
         )
-        db.insertSample(p, timestampMs = 1_000)
-        val samples = db.samplesInWindow(pid = 5, startMs = 0, endMs = 2_000)
+        db.save(p, timestampMs = 1_000)
+        val samples = db.samples(pid = 5, fromMs = 0, toMs = 2_000)
         assertEquals(1, samples.size)
         assertEquals(300L, samples[0].first)
     }
@@ -84,10 +87,10 @@ class WatcherDatabaseTest {
             status = "RUNNING",
         )
 
-        db.insertSample(p, timestampMs = 1_000)
+        db.save(p, timestampMs = 1_000)
 
-        assertEquals(1L, db.processSampleCount(ProcessType.KOTLIN_DAEMON))
-        assertEquals(0L, db.processSampleCount(ProcessType.GRADLE_DAEMON))
+        assertEquals(1L, db.countByType(ProcessType.KOTLIN_DAEMON))
+        assertEquals(0L, db.countByType(ProcessType.GRADLE_DAEMON))
     }
 
     @Test
@@ -96,8 +99,8 @@ class WatcherDatabaseTest {
         val now = 100L * 24 * 60 * 60 * 1000 // day 100
         val old = now - 8L * 24 * 60 * 60 * 1000 // 8 days ago (> 7d retention)
         val recent = now - 1L * 24 * 60 * 60 * 1000 // 1 day ago
-        db.insertBuild(build("old", old))
-        db.insertBuild(build("recent", recent))
+        db.save(build("old", old))
+        db.save(build("recent", recent))
         db.purgeOlderThan(now, retentionDays = 7)
         val rows = db.buildsFlow().first()
         assertEquals(listOf("recent"), rows.map { it.buildId })
@@ -124,6 +127,45 @@ class WatcherDatabaseTest {
         Files.delete(path)
 
         assertTrue(!path.exists())
+    }
+
+    @Test
+    fun `repository ports expose build sample and retention operations`(@TempDirArg tmp: Path) {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        val builds: BuildRepository = database
+        val samples: ProcessSampleRepository = database
+        val retention: RetentionRepository = database
+
+        samples.save(
+            GradleProcess(
+                pid = 11,
+                parentPid = 1,
+                type = ProcessType.GRADLE_DAEMON,
+                commandLine = "java GradleDaemon",
+                workingDirectory = "/repo",
+                projectPath = "/repo",
+                cpuPercent = 1.0,
+                rssMemoryMb = 400,
+                maxHeapMb = 1024,
+                minHeapMb = null,
+                gc = null,
+                startTimeMs = 1,
+                status = "RUNNING",
+            ),
+            timestampMs = 5_000,
+        )
+        builds.save(build("port-build", 5_000, project = "/repo"))
+
+        assertEquals(listOf("port-build"), builds.recent().map { it.buildId })
+        assertEquals(listOf("/repo"), builds.distinctProjects())
+        assertEquals(1, builds.search("port", limit = 10).size)
+        assertEquals(1, builds.findByDaemon(1, limit = 10).size)
+        assertEquals(listOf(400L to 1.0), samples.samples(11, fromMs = 0, toMs = 10_000))
+        assertEquals(1, samples.findByPid(11, limit = 10).size)
+        assertEquals(1, samples.recentSamples(limit = 10).size)
+
+        retention.purgeOlderThan(nowMs = 5_000 + 8L * 24 * 60 * 60 * 1000, retentionDays = 7)
+        assertTrue(builds.recent().isEmpty())
     }
 }
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/ProcessTypeIconAndPillsUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/ProcessTypeIconAndPillsUiTest.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.ProcessType
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import kotlin.test.Test
 import kotlin.test.assertTrue
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/ThemeUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/common/ThemeUiTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/history/HistoryScreenUiTest.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.test.runComposeUiTest
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.Source
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.ui.common.WatcherTheme
 import kotlin.test.Test
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/LiveMonitorScreenUiTest.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.test.swipeUp
 import androidx.compose.ui.unit.dp
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.ui.common.WatcherTheme
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsScreenUiTest.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.compose.ui.test.runComposeUiTest
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.update.UpdateCandidate
 import io.github.cdsap.daemonitor.ui.common.WatcherTheme
 import io.github.cdsap.daemonitor.ui.common.WatcherDarkColors

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -1,7 +1,7 @@
 package io.github.cdsap.daemonitor.ui.settings
 
 import io.github.cdsap.daemonitor.config.RetentionPolicy
-import io.github.cdsap.daemonitor.store.AppearancePreference
+import io.github.cdsap.daemonitor.persistence.AppearancePreference
 import io.github.cdsap.daemonitor.update.StagedUpdate
 import io.github.cdsap.daemonitor.update.UpdateApplier
 import io.github.cdsap.daemonitor.update.UpdateCandidate


### PR DESCRIPTION
## Summary

Automated cursor implementation for cdsap/daemonitor#91: Introduce persistence repository ports

Fixes #91

## Agent routing

- Selected agent: `cursor`
- Routing reason: `codex_capacity_insufficient`
- Complexity: `large`

## Verification

- `./gradlew test`