### PR TITLE
feat: make visual tab show historic memory trends

### DIFF
--- a/docs/plans/2026-08-31-0733-spike-visual-trend-graph-plan.md
+++ b/docs/plans/2026-08-31-0733-spike-visual-trend-graph-plan.md
@@ -1,0 +1,217 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+created: 2026-08-31
+title: Visual Trend Graph Spike
+---
+
+# Visual Trend Graph Spike
+
+## Goal Capsule
+
+Make the Visual tab feel like a process memory profiler instead of a static snapshot. The tab should show smooth, readable RSS and configured heap-limit trends over selectable historical windows, starting with short retained process history such as 15 minutes and 1 hour.
+
+## Product Contract
+
+### Requirements
+
+- **R1 · Smooth trend graph.** Replace the current point-to-point visual treatment with a smoother trend rendering for RSS and configured heap-limit series.
+- **R2 · Time-window control.** Add a visible range control for recent process history. Initial ranges: `Live`, `15 min`, `1 hour`, and `All retained`.
+- **R3 · Persisted history source.** Ranges longer than the current live buffer must load from persisted `process_samples`, not from tab-local state.
+- **R4 · Process selection remains first-class.** Selecting a process/series should keep the selected process visually emphasized and keep legend toggles useful when many processes exist.
+- **R5 · Honest heap semantics.** Continue labeling heap as configured heap limit / `-Xmx`, not live heap occupancy, unless a future attach-based collector is explicitly added.
+- **R6 · Good empty/degraded states.** If the selected range has no persisted samples, show an explicit empty trend state; if a process has no heap limit, omit or mute its heap line rather than drawing a false zero.
+
+### Non-Goals
+
+- Do not attach to JVMs or collect live heap occupancy in this spike.
+- Do not add alerting/anomaly detection yet.
+- Do not replace the Live table or Build history views.
+- Do not add remote telemetry.
+
+### Acceptance Examples
+
+- **AE1.** With four live Gradle-related processes and 90 retained samples, `Live` shows a smooth total RSS trend plus selectable per-process RSS/heap series.
+- **AE2.** Switching to `1 hour` reloads the chart from SQLite and preserves the selected process when that PID appears in the range.
+- **AE3.** A process with `max_heap_mb = NULL` shows RSS but no heap-limit line.
+- **AE4.** A range with no samples renders a compact "No samples in this range" state rather than an empty chart.
+
+## Current Repo Grounding
+
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/common/AppScaffold.kt` already exposes a `Visual` tab.
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreen.kt` renders `OverallRssTimelineChart` and refreshes tab panel state every 30 seconds.
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/LiveViewModel.kt` keeps an in-memory `rssTimeline` with `DEFAULT_TIMELINE_CAPACITY = 90`.
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt` draws each series with a Canvas `Path` built by straight `lineTo` segments.
+- `src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq` already persists `process_samples` with `timestamp`, `pid`, `process_type`, `project_path`, `cpu_percent`, `rss_memory_mb`, and `max_heap_mb`.
+- `src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt` exposes recent samples and PID-specific samples, but not range/group queries shaped for the Visual tab.
+
+## Technical Design
+
+### Decision 1: Treat `Live` and historic ranges as different data sources
+
+`Live` should continue using `LiveUiState.rssTimeline` for fast in-memory updates. Historic ranges should query `process_samples` from persistence through an application-level repository method.
+
+This avoids making the live ViewModel own retention-scale history and keeps the UI honest when a tab is opened after the app has already been running.
+
+### Decision 2: Add a Visual-specific state holder
+
+Add a `VisualViewModel` or equivalent application state holder rather than overloading `LiveViewModel`.
+
+Responsibilities:
+
+- Track selected range.
+- Track visible/selected series.
+- Load range samples from the process-sample repository.
+- Merge current live process metadata into historic samples for labels when available.
+- Expose loading, empty, and error states.
+
+### Decision 3: Downsample for smoothness and stability
+
+Add a model-layer downsampling step before drawing:
+
+- `Live`: no downsampling unless point count exceeds the plot width.
+- `15 min`: bucket by about 10 seconds.
+- `1 hour`: bucket by about 30 seconds.
+- `All retained`: bucket to a target max of roughly 240 points.
+
+For each bucket, preserve max RSS, average CPU if shown later, and latest heap limit.
+
+### Decision 4: Draw a smoothed path without hiding spikes
+
+Use monotone cubic interpolation or Catmull-Rom-to-Bezier conversion with clamped control points. Smooth the visual path, but keep hover points and bucket values exact. Do not use a moving average as the default because it can hide real peak RSS spikes.
+
+### Decision 5: Keep controls compact and profiler-like
+
+The Visual tab should have:
+
+- A range segmented control near the chart title.
+- Optional refresh/status text only when useful: last sample time, loading, or no samples.
+- Legend chips that can be toggled, but with process rows collapsed if there are too many series.
+- A selected-process summary strip beside or below the chart with current RSS, peak RSS in range, heap limit, and sample count.
+
+## Implementation Units
+
+### U1 · Range Queries
+
+Files:
+
+- `src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq`
+- `src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt`
+- `src/main/kotlin/io/github/cdsap/daemonitor/application/ProcessSampleRepository.kt`
+- Tests: `src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt`
+
+Plan:
+
+- Add a query for process samples between `fromMs` and `toMs`, ordered ascending by timestamp.
+- Return full sample fields needed for labels, RSS, heap, and process type.
+- Keep existing retention purge behavior unchanged.
+
+Test Scenarios:
+
+- Samples outside the selected range are excluded.
+- Results are timestamp ascending.
+- Null `max_heap_mb` stays null.
+- Multiple PIDs in one range are preserved.
+
+### U2 · Visual Range State
+
+Files:
+
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModel.kt`
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualUiState.kt`
+- `src/main/kotlin/io/github/cdsap/daemonitor/Main.kt`
+- Tests: `src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModelTest.kt`
+
+Plan:
+
+- Define `VisualRange` values: `LIVE`, `FIFTEEN_MINUTES`, `ONE_HOUR`, `ALL_RETAINED`.
+- Use `LiveUiState.rssTimeline` for `LIVE`.
+- Query persisted samples for the other ranges.
+- Preserve selection when possible; otherwise select the highest RSS process in the visible range.
+
+Test Scenarios:
+
+- Selecting `1 hour` calls the repository with the expected time window.
+- Switching back to `Live` uses in-memory samples.
+- Selection survives range changes when the PID exists.
+- Empty repository result produces an empty state.
+
+### U3 · Chart Model Downsampling
+
+Files:
+
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModel.kt`
+- Tests: `src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModelTest.kt`
+
+Plan:
+
+- Convert persisted process samples into `RssTimelineChartData`.
+- Add bucketed downsampling by range.
+- Include total RSS per bucket and per-PID RSS/heap series.
+- Preserve peak RSS in each bucket to keep spikes visible.
+
+Test Scenarios:
+
+- One bucket with multiple points keeps max RSS.
+- Heap limit uses the latest non-null value in the bucket.
+- Total RSS aggregates PIDs by timestamp bucket.
+- Downsampling never returns more than the target point count for long ranges.
+
+### U4 · Smooth Chart Rendering
+
+Files:
+
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt`
+- Tests: `src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModelTest.kt`
+- Optional screenshot: `src/test/kotlin/io/github/cdsap/daemonitor/docs/ReadmeScreenshotCapture.kt`
+
+Plan:
+
+- Replace straight-line path generation with a smooth path helper.
+- Keep exact point positions for hover/crosshair.
+- Do not smooth dashed heap lines differently from RSS except for stroke style.
+- Add model tests for generated path control behavior if the helper is pure enough; otherwise keep rendering covered by UI/screenshot tests.
+
+Test Scenarios:
+
+- Single-point and two-point series render without path errors.
+- Multi-point series produces a continuous path.
+- Hover still resolves the nearest exact point.
+
+### U5 · Visual Tab Controls and Polish
+
+Files:
+
+- `src/main/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreen.kt`
+- `src/test/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreenUiTest.kt`
+- `src/test/kotlin/io/github/cdsap/daemonitor/docs/ReadmeScreenshotCapture.kt`
+
+Plan:
+
+- Add the range segmented control.
+- Add selected-process summary metrics.
+- Add no-samples and loading states.
+- Update screenshot fixtures so the Visual tab demonstrates a real historic range.
+
+Test Scenarios:
+
+- The range control renders all expected options.
+- Clicking `1 hour` changes chart title/status and uses historic state.
+- Empty historic samples show "No samples in this range".
+- Screenshot rendering includes the Visual tab without clipped labels.
+
+## Risks
+
+- Long retained ranges can create too many series if many short-lived test workers exist. Mitigate with top-N visible series plus total RSS by default.
+- PID reuse can confuse historic labels. Mitigate by including process type, project path, and start-time-like grouping when available; document that PID-only identity is best-effort.
+- Smooth curves can visually overshoot. Use monotone/clamped interpolation and keep exact hover values.
+- `max_heap_mb` is configured allocation limit, not live heap usage. Keep label text explicit.
+
+## Validation Plan
+
+- Run focused model/database/UI tests for the Visual tab.
+- Run `./gradlew test --no-daemon --stacktrace`.
+- Regenerate README screenshots if the visible navigation or chart screenshot changes.
+- Manually run the app and verify `Live`, `15 min`, and `1 hour` controls against a real Gradle build workload.
+

--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
@@ -61,6 +61,7 @@ class AppContainer(
             ioDispatcher = ioDispatcher,
             pollInterval = MonitoringConfig.DEFAULT.pollInterval,
         ),
+        processSamples = database,
         uiDispatcher = uiDispatcher,
         clock = clock,
     )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/Main.kt
@@ -96,6 +96,7 @@ internal fun DaemonitorContent(
     WatcherTheme(appearance = settingsState.appearance) {
         Surface(modifier = Modifier.fillMaxSize()) {
             val liveState by service.liveViewModel.state.collectAsState()
+            val visualState by service.visualViewModel.state.collectAsState()
             AppScaffold(
                 onSwitchToHeadless = onSwitchToHeadless,
                 settingsNotificationCount = settingsState.updateNotificationCount,
@@ -108,7 +109,12 @@ internal fun DaemonitorContent(
                     )
                 },
                 visualContent = {
-                    ProcessVisualScreen(state = liveState)
+                    ProcessVisualScreen(
+                        state = liveState,
+                        visualState = visualState,
+                        onRange = service.visualViewModel::selectRange,
+                        onSelectProcess = service.visualViewModel::selectProcess,
+                    )
                 },
                 historyContent = {
                     val historyState by service.historyViewModel.state.collectAsState()

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherService.kt
@@ -1,10 +1,12 @@
 package io.github.cdsap.daemonitor
 
 import io.github.cdsap.daemonitor.application.update.UpdateService
+import io.github.cdsap.daemonitor.application.ProcessSampleRepository
 import io.github.cdsap.daemonitor.store.SettingsStore
 import io.github.cdsap.daemonitor.store.WatcherDatabase
 import io.github.cdsap.daemonitor.ui.history.HistoryViewModel
 import io.github.cdsap.daemonitor.ui.live.LiveViewModel
+import io.github.cdsap.daemonitor.ui.live.VisualViewModel
 import io.github.cdsap.daemonitor.ui.settings.McpUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsUiState
 import io.github.cdsap.daemonitor.ui.settings.SettingsViewModel
@@ -25,11 +27,18 @@ class WatcherService(
     private val mcpController: McpServiceController,
     private val updateService: UpdateService,
     private val monitoringService: MonitoringService,
+    private val processSamples: ProcessSampleRepository,
     private val uiDispatcher: CoroutineDispatcher = Dispatchers.Main,
     private val clock: () -> Long = System::currentTimeMillis,
 ) {
     val liveViewModel = LiveViewModel()
     val historyViewModel = HistoryViewModel()
+    val visualViewModel = VisualViewModel(
+        processSamples = processSamples,
+        scope = CoroutineScope(SupervisorJob() + uiDispatcher),
+        ioDispatcher = Dispatchers.IO,
+        clockMs = clock,
+    )
 
     private val initialSettings = settingsService.load()
 
@@ -126,6 +135,7 @@ class WatcherService(
         val selectedTail = selectedDaemonTail(result)
         withContext(uiDispatcher) {
             liveViewModel.onPoll(result.processes, selectedTail)
+            visualViewModel.onLiveState(liveViewModel.state.value)
         }
         if (result.buildsChanged) refreshHistory()
     }
@@ -136,6 +146,7 @@ class WatcherService(
                 val selectedTail = selectedDaemonTail(result)
                 withContext(uiDispatcher) {
                     liveViewModel.onPoll(result.processes, selectedTail)
+                    visualViewModel.onLiveState(liveViewModel.state.value)
                 }
                 if (result.buildsChanged) refreshHistory()
             },
@@ -182,6 +193,7 @@ class WatcherService(
                     pollAction = pollAction,
                     ioDispatcher = ioDispatcher,
                 ),
+                processSamples = database,
                 uiDispatcher = uiDispatcher,
                 clock = clock,
             )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/ProcessSampleRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/ProcessSampleRepository.kt
@@ -1,8 +1,11 @@
 package io.github.cdsap.daemonitor.application
 
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.persistence.ProcessSample
 
 /** Port for persisting process samples collected during polling. */
 interface ProcessSampleRepository {
     fun save(sample: GradleProcess, timestampMs: Long)
+
+    fun samplesInRange(fromMs: Long, toMs: Long): List<ProcessSample>
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSampleRepository.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/persistence/ProcessSampleRepository.kt
@@ -12,6 +12,8 @@ interface ProcessSampleRepository {
      */
     fun samples(pid: Long, fromMs: Long, toMs: Long): List<Pair<Long, Double?>>
 
+    fun samplesInRange(fromMs: Long, toMs: Long): List<ProcessSample>
+
     fun recentSamples(limit: Long = BuildRepository.DEFAULT_QUERY_LIMIT): List<ProcessSample>
     fun findByPid(pid: Long, limit: Long = BuildRepository.DEFAULT_QUERY_LIMIT): List<ProcessSample>
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabase.kt
@@ -148,6 +148,10 @@ class WatcherDatabase private constructor(
     override fun recentSamples(limit: Long): List<ProcessSample> =
         recentProcessSamples(limit)
 
+    override fun samplesInRange(fromMs: Long, toMs: Long): List<ProcessSample> =
+        db.watcherQueries.processSamplesInRange(fromMs, toMs).executeAsList()
+            .map { it.toDomain() }
+
     fun processSamplesForPid(pid: Long, limit: Long = DEFAULT_QUERY_LIMIT): List<ProcessSample> =
         db.watcherQueries.processSamplesForPid(pid, limit.coerceQueryLimit()).executeAsList()
             .map { it.toDomain() }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreen.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreen.kt
@@ -12,39 +12,38 @@ import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.Storage
 import androidx.compose.material.icons.filled.Timeline
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.ui.common.EmptyState
 import io.github.cdsap.daemonitor.ui.common.LocalAccentColors
 import io.github.cdsap.daemonitor.ui.common.ScreenHeader
 import io.github.cdsap.daemonitor.ui.common.Space
 import io.github.cdsap.daemonitor.ui.common.StatTile
 import io.github.cdsap.daemonitor.ui.live.charts.OverallRssTimelineChart
-import kotlinx.coroutines.delay
-
-private const val VISUAL_PANEL_REFRESH_MS = 30_000L
 
 @Composable
-fun ProcessVisualScreen(state: LiveUiState) {
-    val latestState by rememberUpdatedState(state)
-    // While this tab is composed (active), keep a 30s-refreshed snapshot for the chart panels.
-    var panelState by remember { mutableStateOf(state) }
-
-    LaunchedEffect(state.isLoading, state.isEmpty) {
-        panelState = latestState
-    }
-    LaunchedEffect(Unit) {
-        while (true) {
-            delay(VISUAL_PANEL_REFRESH_MS)
-            if (!latestState.isLoading && !latestState.isEmpty) {
-                panelState = latestState
-            }
+fun ProcessVisualScreen(
+    state: LiveUiState,
+    visualState: VisualUiState? = null,
+    onRange: (VisualRange) -> Unit = {},
+    onSelectProcess: (Long) -> Unit = {},
+) {
+    var localPanelState by remember(state) { mutableStateOf(state.toVisualUiState()) }
+    val panelState = visualState ?: localPanelState
+    val selectProcess: (Long) -> Unit = { pid ->
+        if (visualState == null) {
+            localPanelState = localPanelState.withProcessSelection(pid, state.processes)
+        } else {
+            onSelectProcess(pid)
         }
     }
 
@@ -53,47 +52,139 @@ fun ProcessVisualScreen(state: LiveUiState) {
         if (panelState.isLoading) {
             EmptyState("Scanning for Gradle processes...", modifier = Modifier.weight(1f))
         } else if (panelState.isEmpty) {
-            EmptyState("No Gradle processes are running right now.", modifier = Modifier.weight(1f))
+            Column(modifier = Modifier.weight(1f).padding(start = Space.lg, end = Space.lg, bottom = Space.lg)) {
+                VisualRangeHeader(panelState.selectedRange, onRange)
+                EmptyState(panelState.statusText ?: "No samples in this range", modifier = Modifier.weight(1f))
+            }
         } else {
-            VisualDashboard(panelState, modifier = Modifier.weight(1f))
+            VisualDashboard(
+                state = panelState,
+                onRange = onRange,
+                onSelectProcess = selectProcess,
+                modifier = Modifier.weight(1f),
+            )
         }
     }
 }
 
 @Composable
-private fun VisualDashboard(state: LiveUiState, modifier: Modifier = Modifier) {
-    val chartData = remember(state.processes) { VisualChartModel.fromProcesses(state.processes) }
-    val defaultPid = remember(state.processes) { state.processes.maxByOrNull { it.rssMemoryMb }?.pid }
-    var selectedPid by remember(state.processes) { mutableStateOf(defaultPid) }
-    val selected = state.processes.firstOrNull { it.pid == selectedPid } ?: state.processes.first()
-    val windowEndMs = state.rssTimeline.lastOrNull()?.atMs
-    val timelineChart = remember(state.rssTimeline, state.processes, windowEndMs) {
-        VisualChartModel.timelineChart(
-            samples = state.rssTimeline,
-            processes = state.processes,
-            windowEndMs = windowEndMs,
-            windowDurationMs = VisualChartModel.DEFAULT_TIMELINE_WINDOW_MS,
-        )
-    }
-    val selectedHeap = selected.maxHeapMb?.let { "$it MB" } ?: "unavailable"
-
+private fun VisualDashboard(
+    state: VisualUiState,
+    onRange: (VisualRange) -> Unit,
+    onSelectProcess: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selected = state.selectedSummary
+    val selectedHeap = selected?.heapLimitMb?.let { "$it MB" } ?: "unavailable"
     Column(modifier = modifier.padding(start = Space.lg, end = Space.lg, bottom = Space.lg)) {
+        VisualRangeHeader(state.selectedRange, onRange)
         Row(
             modifier = Modifier.fillMaxWidth().padding(bottom = Space.md),
             horizontalArrangement = Arrangement.spacedBy(Space.sm),
         ) {
-            StatTile("Processes", state.summary.activeProcessCount.toString(), Modifier.weight(1f), icon = Icons.Filled.Memory)
-            StatTile("RSS total", "${chartData.totalRssMb} MB", Modifier.weight(1f), icon = Icons.Filled.Storage, accent = LocalAccentColors.current.info)
-            StatTile("Selected heap", selectedHeap, Modifier.weight(1f), icon = Icons.Filled.Timeline, accent = LocalAccentColors.current.warn)
-            StatTile("Projects", state.summary.activeProjectCount.toString(), Modifier.weight(1f), accent = LocalAccentColors.current.brand)
+            StatTile("Processes", state.activeProcessCount.toString(), Modifier.weight(1f), icon = Icons.Filled.Memory)
+            StatTile("RSS total", "${state.currentTotalRssMb} MB", Modifier.weight(1f), icon = Icons.Filled.Storage, accent = LocalAccentColors.current.info)
+            StatTile("Series", state.chart.series.size.toString(), Modifier.weight(1f), icon = Icons.Filled.Timeline, accent = LocalAccentColors.current.warn)
+            StatTile("Projects", state.activeProjectCount.toString(), Modifier.weight(1f), accent = LocalAccentColors.current.brand)
+        }
+        selected?.let { summary ->
+            Text(
+                summary.label,
+                modifier = Modifier.fillMaxWidth().padding(bottom = Space.xs),
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(bottom = Space.md),
+                horizontalArrangement = Arrangement.spacedBy(Space.sm),
+            ) {
+                StatTile("Current RSS", "${summary.currentRssMb} MB", Modifier.weight(1f), accent = LocalAccentColors.current.info)
+                StatTile("Peak RSS", "${summary.peakRssMb} MB", Modifier.weight(1f), accent = LocalAccentColors.current.danger)
+                StatTile("Heap limit", selectedHeap, Modifier.weight(1f), accent = LocalAccentColors.current.warn)
+                StatTile("Samples", summary.sampleCount.toString(), Modifier.weight(1f), accent = LocalAccentColors.current.success)
+            }
         }
 
         OverallRssTimelineChart(
-            chart = timelineChart,
-            currentTotalRssMb = chartData.totalRssMb,
-            selectedPid = selected.pid,
-            onSelectProcess = { selectedPid = it },
+            chart = state.chart,
+            currentTotalRssMb = state.currentTotalRssMb,
+            selectedPid = state.selectedPid,
+            rangeLabel = state.selectedRange.label,
+            statusText = state.statusText,
+            onSelectProcess = onSelectProcess,
             modifier = Modifier.weight(1f).fillMaxWidth(),
         )
     }
+}
+
+@Composable
+private fun VisualRangeHeader(selectedRange: VisualRange, onRange: (VisualRange) -> Unit) {
+    Row(
+        modifier = Modifier.fillMaxWidth().padding(bottom = Space.md),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        SingleChoiceSegmentedButtonRow {
+            VisualRange.entries.forEachIndexed { index, range ->
+                SegmentedButton(
+                    selected = selectedRange == range,
+                    onClick = { onRange(range) },
+                    shape = SegmentedButtonDefaults.itemShape(index, VisualRange.entries.size),
+                ) {
+                    Text(range.label)
+                }
+            }
+        }
+    }
+}
+
+private fun LiveUiState.toVisualUiState(): VisualUiState {
+    val endMs = rssTimeline.lastOrNull()?.atMs
+    val chart = VisualChartModel.timelineChart(
+        samples = rssTimeline,
+        processes = processes,
+        windowEndMs = endMs,
+        windowDurationMs = VisualChartModel.DEFAULT_TIMELINE_WINDOW_MS,
+    )
+    val selectedPid = summary.highestMemoryPid ?: chart.series.firstOrNull { it.pid != null }?.pid
+    return VisualUiState(
+        selectedRange = VisualRange.LIVE,
+        chart = chart,
+        selectedPid = selectedPid,
+        currentTotalRssMb = summary.totalRssMb,
+        activeProcessCount = summary.activeProcessCount,
+        activeProjectCount = summary.activeProjectCount,
+        isLoading = isLoading,
+        isEmpty = chart.points.isEmpty(),
+        statusText = when {
+            chart.points.isNotEmpty() -> "Last sample available"
+            isEmpty && !isLoading -> "No Gradle processes are running right now."
+            else -> "Collecting live samples..."
+        },
+        errorText = pollError?.errorType,
+    ).withProcessSelection(selectedPid, processes)
+}
+
+private fun VisualUiState.withProcessSelection(pid: Long?, processes: List<GradleProcess>): VisualUiState {
+    val summary = pid?.let { chart.selectedSummary(it, processes) }
+    return copy(selectedPid = summary?.pid ?: pid, selectedSummary = summary)
+}
+
+private fun RssTimelineChartData.selectedSummary(
+    pid: Long,
+    processes: List<GradleProcess>,
+): SelectedProcessVisualSummary? {
+    val selectedProcess = processes.firstOrNull { it.pid == pid }
+    val rssValues = points.mapNotNull { it.valuesBySeriesId[VisualChartModel.rssSeriesId(pid)] }
+    if (rssValues.isEmpty()) return null
+    return SelectedProcessVisualSummary(
+        pid = pid,
+        label = selectedProcess?.let { process ->
+            val project = process.projectPath?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+            listOfNotNull(process.type.displayLabel(), project, "PID ${process.pid}").joinToString(" · ")
+        } ?: "PID $pid",
+        currentRssMb = rssValues.last(),
+        peakRssMb = rssValues.maxOrNull() ?: 0,
+        heapLimitMb = selectedProcess?.maxHeapMb,
+        sampleCount = rssValues.count { it > 0 },
+    )
 }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModel.kt
@@ -2,6 +2,8 @@ package io.github.cdsap.daemonitor.ui.live
 
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import kotlin.math.ceil
 
 data class ProcessMemoryBars(
     val pid: Long,
@@ -49,6 +51,7 @@ object VisualChartModel {
     const val TOTAL_SERIES_ID = "total"
     const val TOTAL_HEAP_SERIES_ID = "total-heap"
     const val DEFAULT_TIMELINE_WINDOW_MS = 30_000L
+    const val ALL_RETAINED_TARGET_POINTS = 240
 
     fun fromProcesses(processes: List<GradleProcess>): VisualChartData {
         if (processes.isEmpty()) {
@@ -148,6 +151,82 @@ object VisualChartModel {
         return RssTimelineChartData(series = series, points = points)
     }
 
+    fun timelineChart(
+        samples: List<ProcessSample>,
+        range: VisualRange,
+        liveProcesses: List<GradleProcess>,
+        nowMs: Long,
+    ): RssTimelineChartData {
+        if (samples.isEmpty()) {
+            return RssTimelineChartData(series = emptyList(), points = emptyList())
+        }
+
+        val bucketMs = bucketDurationMs(samples, range, nowMs)
+        val buckets = samples
+            .groupBy { sample -> bucketStart(sample.timestampMs, bucketMs) }
+            .toSortedMap()
+            .map { (_, bucketSamples) -> bucketSamples.toTimelineSample() }
+
+        val liveByPid = liveProcesses.associateBy { it.pid }
+        val latestSampleByPid = samples.groupBy { it.pid }.mapValues { (_, pidSamples) ->
+            pidSamples.maxByOrNull { it.timestampMs }
+        }
+        val pidsByPeak = samples
+            .groupBy { it.pid }
+            .entries
+            .sortedByDescending { (_, pidSamples) -> pidSamples.maxOf { it.rssMemoryMb } }
+            .map { it.key }
+
+        val processSeries = pidsByPeak.flatMap { pid ->
+            val label = liveByPid[pid]?.chartLabel()
+                ?: latestSampleByPid[pid]?.chartLabel()
+                ?: "PID $pid"
+            val hasHeap = samples.any { it.pid == pid && it.maxHeapMb != null } || liveByPid[pid]?.maxHeapMb != null
+            buildList {
+                add(
+                    TimelineSeries(
+                        id = rssSeriesId(pid),
+                        label = "$label · RSS",
+                        pid = pid,
+                        metric = TimelineMetric.RSS,
+                    ),
+                )
+                if (hasHeap) {
+                    add(
+                        TimelineSeries(
+                            id = heapSeriesId(pid),
+                            label = "$label · Heap",
+                            pid = pid,
+                            metric = TimelineMetric.HEAP,
+                        ),
+                    )
+                }
+            }
+        }
+
+        val series = listOf(
+            TimelineSeries(id = TOTAL_SERIES_ID, label = "Total RSS", isTotal = true, metric = TimelineMetric.RSS),
+            TimelineSeries(id = TOTAL_HEAP_SERIES_ID, label = "Total Heap", isTotal = true, metric = TimelineMetric.HEAP),
+        ) + processSeries
+
+        val points = buckets.map { sample ->
+            val values = linkedMapOf<String, Long>()
+            values[TOTAL_SERIES_ID] = sample.totalRssMb
+            values[TOTAL_HEAP_SERIES_ID] = sample.heapByPid.values.sum()
+            processSeries.forEach { item ->
+                val pid = item.pid ?: return@forEach
+                val value = when (item.metric) {
+                    TimelineMetric.RSS -> sample.byPid[pid]
+                    TimelineMetric.HEAP -> sample.heapByPid[pid] ?: liveByPid[pid]?.maxHeapMb
+                } ?: 0L
+                values[item.id] = value
+            }
+            RssTimelinePoint(atMs = sample.atMs, valuesBySeriesId = values)
+        }
+
+        return RssTimelineChartData(series = series, points = points)
+    }
+
     fun rssSeriesId(pid: Long): String = "pid-$pid-rss"
     fun heapSeriesId(pid: Long): String = "pid-$pid-heap"
 
@@ -158,6 +237,42 @@ object VisualChartModel {
 
     private fun fraction(value: Long, scaleMb: Long): Float =
         (value.toFloat() / scaleMb.toFloat()).coerceIn(0f, 1f)
+
+    private fun bucketDurationMs(samples: List<ProcessSample>, range: VisualRange, nowMs: Long): Long {
+        range.bucketMs?.let { return it }
+        if (range != VisualRange.ALL_RETAINED) return 1L
+        val first = samples.firstOrNull()?.timestampMs ?: return 1L
+        val last = maxOf(nowMs, samples.lastOrNull()?.timestampMs ?: first)
+        val duration = (last - first).coerceAtLeast(1L)
+        return ceil(duration.toDouble() / ALL_RETAINED_TARGET_POINTS.toDouble()).toLong().coerceAtLeast(1L)
+    }
+
+    private fun bucketStart(timestampMs: Long, bucketMs: Long): Long =
+        (timestampMs / bucketMs) * bucketMs
+
+    private fun List<ProcessSample>.toTimelineSample(): RssTimelineSample {
+        val ordered = sortedBy { it.timestampMs }
+        val rssByPid = ordered
+            .groupBy { it.pid }
+            .mapValues { (_, pidSamples) -> pidSamples.maxOf { it.rssMemoryMb } }
+        val heapByPid = ordered
+            .groupBy { it.pid }
+            .mapNotNull { (pid, pidSamples) ->
+                pidSamples.asReversed().firstNotNullOfOrNull { it.maxHeapMb }?.let { pid to it }
+            }
+            .toMap()
+        return RssTimelineSample(
+            atMs = ordered.last().timestampMs,
+            totalRssMb = rssByPid.values.sum(),
+            byPid = rssByPid,
+            heapByPid = heapByPid,
+        )
+    }
+
+    private fun ProcessSample.chartLabel(): String {
+        val project = projectPath?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+        return listOfNotNull(processType.displayLabel(), project, "PID $pid").joinToString(" · ")
+    }
 }
 
 internal fun ProcessType.displayLabel(): String = when (this) {

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualUiState.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualUiState.kt
@@ -1,0 +1,35 @@
+package io.github.cdsap.daemonitor.ui.live
+
+enum class VisualRange(
+    val label: String,
+    val windowMs: Long?,
+    val bucketMs: Long?,
+) {
+    LIVE("Live", null, null),
+    FIFTEEN_MINUTES("15 min", 15 * 60 * 1000L, 10 * 1000L),
+    ONE_HOUR("1 hour", 60 * 60 * 1000L, 30 * 1000L),
+    ALL_RETAINED("All retained", null, null),
+}
+
+data class SelectedProcessVisualSummary(
+    val pid: Long,
+    val label: String,
+    val currentRssMb: Long,
+    val peakRssMb: Long,
+    val heapLimitMb: Long?,
+    val sampleCount: Int,
+)
+
+data class VisualUiState(
+    val selectedRange: VisualRange = VisualRange.LIVE,
+    val chart: RssTimelineChartData = RssTimelineChartData(emptyList(), emptyList()),
+    val selectedPid: Long? = null,
+    val selectedSummary: SelectedProcessVisualSummary? = null,
+    val currentTotalRssMb: Long = 0,
+    val activeProcessCount: Int = 0,
+    val activeProjectCount: Int = 0,
+    val isLoading: Boolean = true,
+    val isEmpty: Boolean = true,
+    val statusText: String? = null,
+    val errorText: String? = null,
+)

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModel.kt
@@ -88,7 +88,11 @@ class VisualViewModel(
             activeProjectCount = liveState.summary.activeProjectCount,
             isLoading = liveState.isLoading,
             isEmpty = chart.points.isEmpty(),
-            statusText = if (chart.points.isEmpty() && !liveState.isLoading) "Collecting live samples..." else lastSampleText(chart),
+            statusText = when {
+                chart.points.isNotEmpty() -> lastSampleText(chart)
+                liveState.isEmpty && !liveState.isLoading -> "No Gradle processes are running right now."
+                else -> "Collecting live samples..."
+            },
             errorText = liveState.pollError?.errorType,
         ).withSelection(nextPid)
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModel.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModel.kt
@@ -1,0 +1,160 @@
+package io.github.cdsap.daemonitor.ui.live
+
+import io.github.cdsap.daemonitor.application.ProcessSampleRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class VisualViewModel(
+    private val processSamples: ProcessSampleRepository,
+    private val scope: CoroutineScope,
+    private val clockMs: () -> Long = { System.currentTimeMillis() },
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    private val _state = MutableStateFlow(VisualUiState())
+    val state: StateFlow<VisualUiState> = _state.asStateFlow()
+
+    private var latestLiveState: LiveUiState = LiveUiState()
+    private var selectedPid: Long? = null
+    private var loadGeneration = 0
+
+    fun onLiveState(liveState: LiveUiState) {
+        latestLiveState = liveState
+        if (_state.value.selectedRange == VisualRange.LIVE) {
+            publishLive(liveState)
+        }
+    }
+
+    fun selectRange(range: VisualRange) {
+        if (range == VisualRange.LIVE) {
+            publishLive(latestLiveState, selectedRange = range)
+            return
+        }
+
+        val generation = ++loadGeneration
+        _state.value = _state.value.copy(selectedRange = range, isLoading = true, errorText = null)
+        scope.launch {
+            val now = clockMs()
+            val fromMs = range.windowMs?.let { now - it } ?: 0L
+            val result = runCatching {
+                withContext(ioDispatcher) { processSamples.samplesInRange(fromMs, now) }
+            }
+            if (generation != loadGeneration) return@launch
+            result
+                .onSuccess { publishHistorical(range, it, now) }
+                .onFailure { error ->
+                    _state.value = _state.value.copy(
+                        selectedRange = range,
+                        isLoading = false,
+                        isEmpty = true,
+                        errorText = error.message ?: error::class.simpleName ?: "Could not load samples",
+                        statusText = "Could not load samples",
+                    )
+                }
+        }
+    }
+
+    fun selectProcess(pid: Long) {
+        selectedPid = pid
+        _state.value = _state.value.withSelection(pid)
+    }
+
+    private fun publishLive(liveState: LiveUiState, selectedRange: VisualRange = VisualRange.LIVE) {
+        loadGeneration += 1
+        val endMs = liveState.rssTimeline.lastOrNull()?.atMs
+        val chart = VisualChartModel.timelineChart(
+            samples = liveState.rssTimeline,
+            processes = liveState.processes,
+            windowEndMs = endMs,
+            windowDurationMs = VisualChartModel.DEFAULT_TIMELINE_WINDOW_MS,
+        )
+        val nextPid = chooseSelectedPid(chart, selectedPid)
+        selectedPid = nextPid
+        _state.value = VisualUiState(
+            selectedRange = selectedRange,
+            chart = chart,
+            selectedPid = nextPid,
+            currentTotalRssMb = liveState.summary.totalRssMb,
+            activeProcessCount = liveState.summary.activeProcessCount,
+            activeProjectCount = liveState.summary.activeProjectCount,
+            isLoading = liveState.isLoading,
+            isEmpty = chart.points.isEmpty(),
+            statusText = if (chart.points.isEmpty() && !liveState.isLoading) "Collecting live samples..." else lastSampleText(chart),
+            errorText = liveState.pollError?.errorType,
+        ).withSelection(nextPid)
+    }
+
+    private fun publishHistorical(range: VisualRange, samples: List<ProcessSample>, nowMs: Long) {
+        val chart = VisualChartModel.timelineChart(
+            samples = samples,
+            range = range,
+            liveProcesses = latestLiveState.processes,
+            nowMs = nowMs,
+        )
+        val nextPid = chooseSelectedPid(chart, selectedPid)
+        selectedPid = nextPid
+        _state.value = VisualUiState(
+            selectedRange = range,
+            chart = chart,
+            selectedPid = nextPid,
+            currentTotalRssMb = chart.points.lastOrNull()?.valuesBySeriesId?.get(VisualChartModel.TOTAL_SERIES_ID) ?: 0,
+            activeProcessCount = latestLiveState.summary.activeProcessCount,
+            activeProjectCount = latestLiveState.summary.activeProjectCount,
+            isLoading = false,
+            isEmpty = chart.points.isEmpty(),
+            statusText = if (chart.points.isEmpty()) {
+                "No samples in this range"
+            } else {
+                "${samples.size} retained samples · ${lastSampleText(chart)}"
+            },
+            errorText = null,
+        ).withSelection(nextPid)
+    }
+
+    private fun VisualUiState.withSelection(pid: Long?): VisualUiState {
+        val summary = pid?.let { selectedSummary(chart, it) }
+        return copy(selectedPid = summary?.pid ?: pid, selectedSummary = summary)
+    }
+
+    private fun selectedSummary(chart: RssTimelineChartData, pid: Long): SelectedProcessVisualSummary? {
+        val rssId = VisualChartModel.rssSeriesId(pid)
+        val heapId = VisualChartModel.heapSeriesId(pid)
+        val rssValues = chart.points.mapNotNull { it.valuesBySeriesId[rssId] }
+        if (rssValues.isEmpty()) return null
+        val seriesLabel = chart.series.firstOrNull { it.id == rssId }?.label?.removeSuffix(" · RSS") ?: "PID $pid"
+        return SelectedProcessVisualSummary(
+            pid = pid,
+            label = seriesLabel,
+            currentRssMb = rssValues.last(),
+            peakRssMb = rssValues.maxOrNull() ?: 0L,
+            heapLimitMb = chart.points.asReversed().firstNotNullOfOrNull { point ->
+                point.valuesBySeriesId[heapId]?.takeIf { it > 0 }
+            },
+            sampleCount = rssValues.count { it > 0 },
+        )
+    }
+
+    private fun chooseSelectedPid(chart: RssTimelineChartData, preferredPid: Long?): Long? {
+        val pids = chart.series.mapNotNull { it.pid }.distinct()
+        if (preferredPid in pids) return preferredPid
+        return pids.maxByOrNull { pid ->
+            val rssId = VisualChartModel.rssSeriesId(pid)
+            chart.points.maxOfOrNull { it.valuesBySeriesId[rssId] ?: 0L } ?: 0L
+        }
+    }
+
+    private fun lastSampleText(chart: RssTimelineChartData): String? =
+        chart.points.lastOrNull()?.let { "Last sample ${formatClock(it.atMs)}" }
+
+    private fun formatClock(atMs: Long): String =
+        SimpleDateFormat("h:mm:ss a", Locale.US).format(Date(atMs))
+}

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt
@@ -67,6 +67,8 @@ private data class HoverLegend(
     val markerYs: List<Pair<Color, Float>>,
 )
 
+private const val DEFAULT_VISIBLE_PROCESS_LIMIT = 4
+
 @Composable
 fun OverallRssTimelineChart(
     chart: RssTimelineChartData,
@@ -117,8 +119,8 @@ fun OverallRssTimelineChart(
     val crosshairColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.35f)
     val points = chart.points
     val series = chart.series
-    var visibleIds by remember(series.map { it.id }) {
-        mutableStateOf(series.map { it.id }.toSet())
+    var visibleIds by remember(series.map { it.id }, selectedPid) {
+        mutableStateOf(defaultVisibleSeriesIds(series, selectedPid))
     }
     var hover by remember(points, visibleIds) { mutableStateOf<HoverLegend?>(null) }
     var plotSize by remember { mutableStateOf(IntSize.Zero) }
@@ -335,6 +337,25 @@ fun OverallRssTimelineChart(
             }
         }
     }
+}
+
+internal fun defaultVisibleSeriesIds(series: List<TimelineSeries>, selectedPid: Long?): Set<String> {
+    val totalIds = series.filter { it.isTotal }.map { it.id }
+    val processIds = series
+        .mapNotNull { it.pid }
+        .distinct()
+        .take(DEFAULT_VISIBLE_PROCESS_LIMIT)
+        .let { ids ->
+            if (selectedPid != null && selectedPid !in ids && series.any { it.pid == selectedPid }) {
+                ids + selectedPid
+            } else {
+                ids
+            }
+        }
+    val selectedProcessSeriesIds = series
+        .filter { it.pid in processIds }
+        .map { it.id }
+    return (totalIds + selectedProcessSeriesIds).toSet()
 }
 
 @Composable

--- a/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChart.kt
@@ -58,6 +58,7 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.math.roundToInt
 
 private data class HoverLegend(
@@ -73,6 +74,8 @@ fun OverallRssTimelineChart(
     selectedPid: Long?,
     onSelectProcess: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    rangeLabel: String = "Live",
+    statusText: String? = null,
 ) {
     val accents = LocalAccentColors.current
     val palette = remember(accents) {
@@ -129,12 +132,15 @@ fun OverallRssTimelineChart(
             verticalArrangement = Arrangement.spacedBy(Space.sm),
         ) {
             Text(
-                "Total $currentTotalRssMb MB RSS · $processCount processes",
+                "$rangeLabel · Total $currentTotalRssMb MB RSS · $processCount processes",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
             )
             Text(
-                "Solid = RSS, dashed = Heap (-Xmx). Click a series to show or hide it.",
+                listOfNotNull(
+                    "Solid = RSS, dashed = configured heap limit (-Xmx). Click a series to show or hide it.",
+                    statusText,
+                ).joinToString(" "),
                 style = MaterialTheme.typography.labelSmall,
                 color = labelColor,
             )
@@ -251,7 +257,7 @@ fun OverallRssTimelineChart(
 
                                 visibleSeries.forEach { item ->
                                     val color = seriesColors.getValue(item.id)
-                                    val path = pathFor(points, width, height, maxMb) {
+                                    val path = smoothedPathFor(points, width, height, maxMb) {
                                         (it.valuesBySeriesId[item.id] ?: 0L).toFloat()
                                     }
                                     if (item.isTotal && item.metric == TimelineMetric.RSS) {
@@ -454,7 +460,7 @@ private fun nearestIndex(pointCount: Int, width: Float, x: Float): Int {
     return (x / step).roundToInt().coerceIn(0, pointCount - 1)
 }
 
-private fun pathFor(
+private fun smoothedPathFor(
     points: List<RssTimelinePoint>,
     width: Float,
     height: Float,
@@ -464,13 +470,38 @@ private fun pathFor(
     val path = Path()
     if (points.isEmpty()) return path
     val xStep = if (points.size == 1) 0f else width / (points.size - 1).toFloat()
-    points.forEachIndexed { index, point ->
+    val offsets = points.mapIndexed { index, point ->
         val x = index * xStep
         val y = height - (valueOf(point) / maxMb.toFloat()) * height
-        if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        Offset(x, y.coerceIn(0f, height))
+    }
+    path.moveTo(offsets.first().x, offsets.first().y)
+    if (offsets.size == 1) return path
+    if (offsets.size == 2) {
+        path.lineTo(offsets.last().x, offsets.last().y)
+        return path
+    }
+
+    for (index in 0 until offsets.lastIndex) {
+        val previous = offsets.getOrElse(index - 1) { offsets[index] }
+        val current = offsets[index]
+        val next = offsets[index + 1]
+        val following = offsets.getOrElse(index + 2) { next }
+        val control1 = Offset(
+            x = current.x + (next.x - previous.x) / 6f,
+            y = (current.y + (next.y - previous.y) / 6f).coerceBetween(current.y, next.y),
+        )
+        val control2 = Offset(
+            x = next.x - (following.x - current.x) / 6f,
+            y = (next.y - (following.y - current.y) / 6f).coerceBetween(current.y, next.y),
+        )
+        path.cubicTo(control1.x, control1.y, control2.x, control2.y, next.x, next.y)
     }
     return path
 }
+
+private fun Float.coerceBetween(a: Float, b: Float): Float =
+    coerceIn(min(a, b), max(a, b))
 
 private fun formatClock(atMs: Long): String =
     SimpleDateFormat("h:mm:ss a", Locale.US).format(Date(atMs))

--- a/src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq
+++ b/src/main/sqldelight/io/github/cdsap/daemonitor/store/db/Watcher.sq
@@ -105,6 +105,12 @@ FROM process_samples
 ORDER BY timestamp DESC
 LIMIT ?;
 
+processSamplesInRange:
+SELECT *
+FROM process_samples
+WHERE timestamp >= ? AND timestamp <= ?
+ORDER BY timestamp ASC;
+
 processSamplesForPid:
 SELECT *
 FROM process_samples

--- a/src/test/kotlin/io/github/cdsap/daemonitor/application/PollMonitoringTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/application/PollMonitoringTest.kt
@@ -10,6 +10,7 @@ import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.IdleMark
 import io.github.cdsap.daemonitor.domain.model.Outcome
 import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.persistence.ProcessSample
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -137,5 +138,7 @@ class PollMonitoringTest {
         override fun save(sample: GradleProcess, timestampMs: Long) {
             saved += sample to timestampMs
         }
+
+        override fun samplesInRange(fromMs: Long, toMs: Long) = emptyList<ProcessSample>()
     }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/store/WatcherDatabaseTest.kt
@@ -167,6 +167,38 @@ class WatcherDatabaseTest {
         retention.purgeOlderThan(nowMs = 5_000 + 8L * 24 * 60 * 60 * 1000, retentionDays = 7)
         assertTrue(builds.recent().isEmpty())
     }
+
+    @Test
+    fun `process samples in range are timestamp ascending and preserve nullable heap`(@TempDirArg tmp: Path) {
+        val database = WatcherDatabase.open(tmp.resolve("watcher.db"))
+        database.save(sample(pid = 21, rss = 100, heap = 512), timestampMs = 1_000)
+        database.save(sample(pid = 22, rss = 300, heap = null), timestampMs = 3_000)
+        database.save(sample(pid = 21, rss = 200, heap = 768), timestampMs = 2_000)
+        database.save(sample(pid = 23, rss = 900, heap = 1024), timestampMs = 4_000)
+
+        val rows = database.samplesInRange(fromMs = 1_500, toMs = 3_000)
+
+        assertEquals(listOf(2_000L, 3_000L), rows.map { it.timestampMs })
+        assertEquals(listOf(21L, 22L), rows.map { it.pid })
+        assertEquals(768L, rows[0].maxHeapMb)
+        assertEquals(null, rows[1].maxHeapMb)
+    }
+
+    private fun sample(pid: Long, rss: Long, heap: Long?) = GradleProcess(
+        pid = pid,
+        parentPid = 1,
+        type = ProcessType.GRADLE_DAEMON,
+        commandLine = "java GradleDaemon",
+        workingDirectory = "/repo",
+        projectPath = "/repo",
+        cpuPercent = 1.0,
+        rssMemoryMb = rss,
+        maxHeapMb = heap,
+        minHeapMb = null,
+        gc = null,
+        startTimeMs = 1,
+        status = "RUNNING",
+    )
 }
 
 private typealias TempDirArg = org.junit.jupiter.api.io.TempDir

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreenUiTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/ProcessVisualScreenUiTest.kt
@@ -34,13 +34,41 @@ class ProcessVisualScreenUiTest {
         onNodeWithText("Overall RSS").assertDoesNotExist()
         onNodeWithText("Memory by process").assertDoesNotExist()
         onNodeWithText("Process inspector").assertDoesNotExist()
-        onNodeWithText("Total 1536 MB RSS · 2 processes").assertExists()
+        onNodeWithText("Live").assertExists()
+        onNodeWithText("15 min").assertExists()
+        onNodeWithText("1 hour").assertExists()
+        onNodeWithText("All retained").assertExists()
+        onNodeWithText("Live · Total 1536 MB RSS · 2 processes").assertExists()
+        onNodeWithText("Solid = RSS, dashed = configured heap limit (-Xmx). Click a series to show or hide it. Last sample available").assertExists()
         onNodeWithText("Total RSS").assertExists()
         onNodeWithText("Total Heap").assertExists()
         onAllNodesWithText("Gradle daemon · checkout · PID 100 · RSS").onFirst().assertExists()
         onAllNodesWithText("Gradle daemon · checkout · PID 100 · Heap").onFirst().assertExists()
         onAllNodesWithText("Test worker · checkout · PID 101 · RSS").onFirst().assertExists()
-        onNodeWithText("SELECTED HEAP").assertExists()
+        onNodeWithText("HEAP LIMIT").assertExists()
+    }
+
+    @Test
+    fun `historic empty range renders explicit no samples state`() = runVisualUiTest {
+        setContent {
+            WatcherTheme {
+                ProcessVisualScreen(
+                    state = LiveUiState(processes = emptyList(), isLoading = false, isEmpty = true),
+                    visualState = VisualUiState(
+                        selectedRange = VisualRange.ONE_HOUR,
+                        isLoading = false,
+                        isEmpty = true,
+                        statusText = "No samples in this range",
+                    ),
+                )
+            }
+        }
+
+        onNodeWithText("Live").assertExists()
+        onNodeWithText("15 min").assertExists()
+        onNodeWithText("1 hour").assertExists()
+        onNodeWithText("All retained").assertExists()
+        onNodeWithText("No samples in this range").assertExists()
     }
 
     @Test

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualChartModelTest.kt
@@ -2,6 +2,7 @@ package io.github.cdsap.daemonitor.ui.live
 
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.persistence.ProcessSample
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -107,6 +108,59 @@ class VisualChartModelTest {
         assertEquals(emptyList(), data.bars)
     }
 
+    @Test
+    fun `historic buckets preserve peak rss and latest heap limit`() {
+        val chart = VisualChartModel.timelineChart(
+            samples = listOf(
+                sample(timestamp = 1_000, pid = 1, rss = 100, heap = 512),
+                sample(timestamp = 2_000, pid = 1, rss = 160, heap = null),
+                sample(timestamp = 9_000, pid = 1, rss = 120, heap = 768),
+            ),
+            range = VisualRange.FIFTEEN_MINUTES,
+            liveProcesses = emptyList(),
+            nowMs = 12_000,
+        )
+
+        val point = chart.points.single()
+        assertEquals(160L, point.valuesBySeriesId[VisualChartModel.rssSeriesId(1)])
+        assertEquals(768L, point.valuesBySeriesId[VisualChartModel.heapSeriesId(1)])
+        assertEquals(160L, point.valuesBySeriesId[VisualChartModel.TOTAL_SERIES_ID])
+        assertEquals(768L, point.valuesBySeriesId[VisualChartModel.TOTAL_HEAP_SERIES_ID])
+    }
+
+    @Test
+    fun `historic total rss aggregates pids inside a bucket`() {
+        val chart = VisualChartModel.timelineChart(
+            samples = listOf(
+                sample(timestamp = 1_000, pid = 1, rss = 100, heap = 512),
+                sample(timestamp = 2_000, pid = 2, rss = 80, heap = null),
+            ),
+            range = VisualRange.FIFTEEN_MINUTES,
+            liveProcesses = emptyList(),
+            nowMs = 12_000,
+        )
+
+        assertEquals(180L, chart.points.single().valuesBySeriesId[VisualChartModel.TOTAL_SERIES_ID])
+        assertEquals(512L, chart.points.single().valuesBySeriesId[VisualChartModel.TOTAL_HEAP_SERIES_ID])
+        assertEquals(null, chart.series.firstOrNull { it.id == VisualChartModel.heapSeriesId(2) })
+    }
+
+    @Test
+    fun `all retained downsampling caps point count`() {
+        val samples = (0..400).map { index ->
+            sample(timestamp = index * 1_000L, pid = 1, rss = index.toLong(), heap = 512)
+        }
+
+        val chart = VisualChartModel.timelineChart(
+            samples = samples,
+            range = VisualRange.ALL_RETAINED,
+            liveProcesses = emptyList(),
+            nowMs = samples.last().timestampMs,
+        )
+
+        assertTrue(chart.points.size <= VisualChartModel.ALL_RETAINED_TARGET_POINTS)
+    }
+
     private fun process(
         pid: Long,
         type: ProcessType = ProcessType.GRADLE_WRAPPER,
@@ -126,6 +180,20 @@ class VisualChartModelTest {
         minHeapMb = null,
         gc = "G1",
         startTimeMs = 1_700_000_000_000,
+        status = "RUNNING",
+    )
+
+    private fun sample(timestamp: Long, pid: Long, rss: Long, heap: Long?) = ProcessSample(
+        timestampMs = timestamp,
+        pid = pid,
+        parentPid = 1,
+        processType = ProcessType.GRADLE_DAEMON,
+        commandLine = "java GradleDaemon",
+        workingDirectory = "/repo",
+        projectPath = "/repo",
+        cpuPercent = 1.0,
+        rssMemoryMb = rss,
+        maxHeapMb = heap,
         status = "RUNNING",
     )
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModelTest.kt
@@ -1,0 +1,155 @@
+package io.github.cdsap.daemonitor.ui.live
+
+import io.github.cdsap.daemonitor.application.ProcessSampleRepository
+import io.github.cdsap.daemonitor.domain.model.GradleProcess
+import io.github.cdsap.daemonitor.domain.model.ProcessType
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class VisualViewModelTest {
+
+    @Test
+    fun `selecting one hour loads expected persisted range`() = runTest {
+        val repo = RecordingSamples(
+            listOf(sample(timestamp = 9_000, pid = 10, rss = 300, heap = 1024)),
+        )
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val vm = VisualViewModel(repo, TestScope(dispatcher), clockMs = { 10_000 }, ioDispatcher = dispatcher)
+        vm.onLiveState(liveState(listOf(process(pid = 10, rss = 200, heap = 1024))))
+
+        vm.selectRange(VisualRange.ONE_HOUR)
+        advanceUntilIdle()
+
+        assertEquals(10_000 - 60 * 60 * 1000L, repo.lastFromMs)
+        assertEquals(10_000L, repo.lastToMs)
+        assertEquals(VisualRange.ONE_HOUR, vm.state.value.selectedRange)
+        assertEquals(10L, vm.state.value.selectedPid)
+        assertEquals(300L, vm.state.value.selectedSummary?.currentRssMb)
+    }
+
+    @Test
+    fun `switching back to live uses in memory samples`() = runTest {
+        val repo = RecordingSamples(emptyList())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val vm = VisualViewModel(repo, TestScope(dispatcher), clockMs = { 10_000 }, ioDispatcher = dispatcher)
+        vm.onLiveState(liveState(listOf(process(pid = 10, rss = 200, heap = 1024))))
+
+        vm.selectRange(VisualRange.FIFTEEN_MINUTES)
+        advanceUntilIdle()
+        vm.selectRange(VisualRange.LIVE)
+
+        assertEquals(VisualRange.LIVE, vm.state.value.selectedRange)
+        assertEquals(200L, vm.state.value.currentTotalRssMb)
+        assertEquals(10L, vm.state.value.selectedPid)
+        assertEquals(1, repo.callCount)
+    }
+
+    @Test
+    fun `selection survives historic range when pid exists`() = runTest {
+        val repo = RecordingSamples(
+            listOf(
+                sample(timestamp = 8_000, pid = 10, rss = 200, heap = 1024),
+                sample(timestamp = 9_000, pid = 11, rss = 900, heap = 2048),
+            ),
+        )
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val vm = VisualViewModel(repo, TestScope(dispatcher), clockMs = { 10_000 }, ioDispatcher = dispatcher)
+        vm.onLiveState(liveState(listOf(process(pid = 10, rss = 200, heap = 1024))))
+        vm.selectProcess(10)
+
+        vm.selectRange(VisualRange.FIFTEEN_MINUTES)
+        advanceUntilIdle()
+
+        assertEquals(10L, vm.state.value.selectedPid)
+    }
+
+    @Test
+    fun `empty historic range publishes empty state`() = runTest {
+        val repo = RecordingSamples(emptyList())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val vm = VisualViewModel(repo, TestScope(dispatcher), clockMs = { 10_000 }, ioDispatcher = dispatcher)
+        vm.onLiveState(liveState(listOf(process(pid = 10, rss = 200, heap = 1024))))
+
+        vm.selectRange(VisualRange.FIFTEEN_MINUTES)
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.isEmpty)
+        assertEquals("No samples in this range", vm.state.value.statusText)
+    }
+
+    private class RecordingSamples(private val rows: List<ProcessSample>) : ProcessSampleRepository {
+        var lastFromMs: Long? = null
+        var lastToMs: Long? = null
+        var callCount = 0
+
+        override fun save(sample: GradleProcess, timestampMs: Long) = Unit
+
+        override fun samplesInRange(fromMs: Long, toMs: Long): List<ProcessSample> {
+            callCount += 1
+            lastFromMs = fromMs
+            lastToMs = toMs
+            return rows
+        }
+    }
+
+    private fun liveState(processes: List<GradleProcess>): LiveUiState {
+        val total = processes.sumOf { it.rssMemoryMb }
+        return LiveUiState(
+            processes = processes,
+            summary = LiveSummary(
+                activeProcessCount = processes.size,
+                totalRssMb = total,
+                highestMemoryPid = processes.maxByOrNull { it.rssMemoryMb }?.pid,
+                activeProjectCount = 1,
+            ),
+            isLoading = false,
+            isEmpty = processes.isEmpty(),
+            rssTimeline = listOf(
+                RssTimelineSample(
+                    atMs = 10_000,
+                    totalRssMb = total,
+                    byPid = processes.associate { it.pid to it.rssMemoryMb },
+                    heapByPid = processes.mapNotNull { process ->
+                        process.maxHeapMb?.let { process.pid to it }
+                    }.toMap(),
+                ),
+            ),
+        )
+    }
+
+    private fun process(pid: Long, rss: Long, heap: Long?) = GradleProcess(
+        pid = pid,
+        parentPid = 1,
+        type = ProcessType.GRADLE_DAEMON,
+        commandLine = "java GradleDaemon",
+        workingDirectory = "/repo",
+        projectPath = "/repo",
+        cpuPercent = 1.0,
+        rssMemoryMb = rss,
+        maxHeapMb = heap,
+        minHeapMb = null,
+        gc = null,
+        startTimeMs = 1,
+        status = "RUNNING",
+    )
+
+    private fun sample(timestamp: Long, pid: Long, rss: Long, heap: Long?) = ProcessSample(
+        timestampMs = timestamp,
+        pid = pid,
+        parentPid = 1,
+        processType = ProcessType.GRADLE_DAEMON,
+        commandLine = "java GradleDaemon",
+        workingDirectory = "/repo",
+        projectPath = "/repo",
+        cpuPercent = 1.0,
+        rssMemoryMb = rss,
+        maxHeapMb = heap,
+        status = "RUNNING",
+    )
+}

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/VisualViewModelTest.kt
@@ -83,6 +83,24 @@ class VisualViewModelTest {
         assertEquals("No samples in this range", vm.state.value.statusText)
     }
 
+    @Test
+    fun `empty live state keeps explicit no processes copy`() = runTest {
+        val repo = RecordingSamples(emptyList())
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val vm = VisualViewModel(repo, TestScope(dispatcher), clockMs = { 10_000 }, ioDispatcher = dispatcher)
+
+        vm.onLiveState(
+            LiveUiState(
+                processes = emptyList(),
+                isLoading = false,
+                isEmpty = true,
+            ),
+        )
+
+        assertTrue(vm.state.value.isEmpty)
+        assertEquals("No Gradle processes are running right now.", vm.state.value.statusText)
+    }
+
     private class RecordingSamples(private val rows: List<ProcessSample>) : ProcessSampleRepository {
         var lastFromMs: Long? = null
         var lastToMs: Long? = null

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChartTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/live/charts/OverallRssTimelineChartTest.kt
@@ -1,0 +1,34 @@
+package io.github.cdsap.daemonitor.ui.live.charts
+
+import io.github.cdsap.daemonitor.ui.live.TimelineMetric
+import io.github.cdsap.daemonitor.ui.live.TimelineSeries
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class OverallRssTimelineChartTest {
+
+    @Test
+    fun `dense charts show totals top processes and selected process by default`() {
+        val series = listOf(
+            TimelineSeries(id = "total", label = "Total RSS", isTotal = true),
+            TimelineSeries(id = "total-heap", label = "Total Heap", isTotal = true, metric = TimelineMetric.HEAP),
+        ) + (1L..6L).flatMap { pid ->
+            listOf(
+                TimelineSeries(id = "pid-$pid-rss", label = "PID $pid RSS", pid = pid),
+                TimelineSeries(id = "pid-$pid-heap", label = "PID $pid Heap", pid = pid, metric = TimelineMetric.HEAP),
+            )
+        }
+
+        val visible = defaultVisibleSeriesIds(series, selectedPid = 6L)
+
+        assertTrue("total" in visible)
+        assertTrue("total-heap" in visible)
+        assertTrue("pid-1-rss" in visible)
+        assertTrue("pid-4-heap" in visible)
+        assertTrue("pid-6-rss" in visible)
+        assertTrue("pid-6-heap" in visible)
+        assertFalse("pid-5-rss" in visible)
+        assertFalse("pid-5-heap" in visible)
+    }
+}


### PR DESCRIPTION
## Summary

The Visual tab now shows selectable memory history instead of only the current live snapshot. `Live` still uses the in-memory polling buffer, while `15 min`, `1 hour`, and `All retained` load retained process samples from SQLite so the chart remains useful after the tab is opened late.

The chart keeps heap labeling honest as configured `-Xmx` limits, preserves RSS spikes while downsampling historic windows, and defaults dense charts to totals plus the top processes so the first view stays readable.

## Validation

- Focused visual tests passed:
  `./gradlew test --no-daemon --stacktrace --tests io.github.cdsap.daemonitor.ui.live.VisualChartModelTest --tests io.github.cdsap.daemonitor.ui.live.VisualViewModelTest --tests io.github.cdsap.daemonitor.ui.live.ProcessVisualScreenUiTest --tests io.github.cdsap.daemonitor.ui.live.charts.OverallRssTimelineChartTest --tests io.github.cdsap.daemonitor.store.WatcherDatabaseTest`
- Full suite passed:
  `./gradlew test --no-daemon --stacktrace`

Manual app validation against a real Gradle workload is still recommended before release because this is a desktop UI change with runtime process data.

## Post-Deploy Monitoring & Validation

- Watch GitHub Actions for Linux, macOS, and Windows test failures touching `VisualViewModel`, SQLDelight generation, or Compose UI tests.
- After merge, run the desktop app locally with a long Gradle build and verify `Live`, `15 min`, and `1 hour` show non-empty RSS trends.
- Healthy signal: Visual tab range switches complete without UI errors, persisted windows show retained samples, and dense process sets remain readable.
- Failure signal: empty historic ranges despite retained `process_samples`, missing heap-limit labels, or UI hangs while switching ranges.
- Validation window: first CI run after merge plus one local desktop smoke test before the next release.
