### PR TITLE
docs: simplify README and release docs voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Website: <https://cdsap.github.io/daemonitor/>
 
 ### Live Monitor
 
-![Live monitor](docs/images/live-monitor.png)
+![Daemonitor Live monitor showing active Gradle processes, metrics, status badges, process details, MCP status, and the headless toolbar action](docs/images/live-monitor.png)
 
 - Running Gradle-related JVMs, by type:
   - 🐘 Gradle daemon · 🐘+🔧 wrapper · Kotlin daemon · 🧪 test worker · ☕ other related JVM
@@ -37,7 +37,7 @@ Website: <https://cdsap.github.io/daemonitor/>
 
 ### Visual
 
-![Visual memory chart](docs/images/process-visual.png)
+![Daemonitor Visual tab showing per-process RSS and configured heap (-Xmx) timelines](docs/images/process-visual.png)
 
 - Rolling RSS and configured-heap (`-Xmx`) timelines
 - Solid lines for RSS, dashed for `-Xmx` when known
@@ -45,7 +45,7 @@ Website: <https://cdsap.github.io/daemonitor/>
 
 ### Historical
 
-![Build history](docs/images/build-history.png)
+![Daemonitor build history showing status and source tags, agent attribution, metrics, and build details](docs/images/build-history.png)
 
 - Reconstructed builds with time, project, duration, peak RSS, status, source, and agent
 - Filter by project and time range

--- a/README.md
+++ b/README.md
@@ -4,22 +4,20 @@
 
 # Daemonitor
 
-> Activity Monitor for your Gradle daemons — see what's building right now, and what built recently.
+> Activity Monitor for your Gradle daemons — what's building now, and what built recently.
 
-Daemonitor is a local desktop app that shows the Gradle activity happening on your machine: which
-daemons, wrappers, and test workers are running, how much memory and CPU they're using, the latest
-daemon-log lines, and a searchable history of past builds — including **which AI coding agent
-triggered each build**. It's built for the agentic-workflow era, where multiple IDEs, terminals, and
-agents can all be driving Gradle at once.
+Daemonitor is a local desktop app for Gradle on your machine. It shows which daemons, wrappers, and
+test workers are running, how much memory and CPU they use, recent daemon-log lines, and a searchable
+history of past builds — including which coding agent started them when that can be detected.
 
-Everything stays on your machine. No telemetry; command lines and logs are best-effort redacted
-before they're ever stored. Outbound network use is limited to GitHub Releases update checks at
-startup or from Settings, plus installer downloads that you explicitly approve.
+Data stays on your machine. Command lines and logs are redacted before storage. The only outbound
+network use is GitHub Releases update checks (at startup or from Settings) and installer downloads
+you approve.
 
 [![CI](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml/badge.svg)](https://github.com/cdsap/daemonitor/actions/workflows/ci.yml)
 ![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-blue)
 
-**Website:** [https://cdsap.github.io/daemonitor/](https://cdsap.github.io/daemonitor/)
+Website: <https://cdsap.github.io/daemonitor/>
 
 ---
 
@@ -27,84 +25,69 @@ startup or from Settings, plus installer downloads that you explicitly approve.
 
 ### Live Monitor
 
-![Daemonitor Live monitor showing active Gradle processes, metrics, status badges, process details, MCP status, and the headless toolbar action](docs/images/live-monitor.png)
+![Live monitor](docs/images/live-monitor.png)
 
-*Live monitor with concurrent Gradle activity and the selected daemon inspector.*
-
-- Every running Gradle-related JVM, classified by type with an at-a-glance icon:
-  - 🐘 **Gradle daemon** · 🐘+🔧 **Gradle wrapper** · the **Kotlin** mark for the Kotlin daemon · 🧪 test worker · ☕ other Gradle-related JVM
-- Per-process **RSS, CPU, and live-ticking uptime**
-- Headline stats: active processes, total RSS, highest-memory PID, active projects
-- Highlight badges: high/critical memory, `MULTI-BUILD` (a project with concurrent build invocations), `AUTOMATED` (CI/script/agent flags)
-- Per-daemon detail with `-Xmx`, GC, working dir, full (redacted) command line, and a live tail of the daemon log
-- Toolbar MCP status indicator next to one-click headless mode when you want collection to continue without the desktop window
+- Running Gradle-related JVMs, by type:
+  - 🐘 Gradle daemon · 🐘+🔧 wrapper · Kotlin daemon · 🧪 test worker · ☕ other related JVM
+- RSS, CPU, and uptime per process
+- Summary stats: active processes, total RSS, highest-memory PID, active projects
+- Badges for high/critical memory, `MULTI-BUILD`, and `AUTOMATED`
+- Detail panel: `-Xmx`, GC, working dir, redacted command line, live daemon-log tail
+- Toolbar action to switch to headless collection (and MCP status when enabled)
 
 ### Visual
 
-![Daemonitor Visual tab showing per-process RSS and configured heap (-Xmx) timelines](docs/images/process-visual.png)
+![Visual memory chart](docs/images/process-visual.png)
 
-*Visual timeline of resident memory and configured heap for live Gradle processes.*
-
-- Full-width **RSS & Heap** chart over a rolling window
-- **Solid** series for RSS, **dashed** for configured heap (`-Xmx`) when recoverable
-- Totals plus a legend for every process — click to show/hide series or focus selected heap
+- Rolling RSS and configured-heap (`-Xmx`) timelines
+- Solid lines for RSS, dashed for `-Xmx` when known
+- Click the legend to hide or focus a series
 
 ### Historical
 
-![Daemonitor build history showing status and source tags, agent attribution, metrics, and build details](docs/images/build-history.png)
+![Build history](docs/images/build-history.png)
 
-*Build history with outcomes, source and agent tags, resource peaks, and a captured log excerpt.*
-
-- Every reconstructed build, with start time, project, duration, peak RSS, **status** (✓ success / ✗ failed / ⚠ interrupted / ◐ completed), **source** (terminal / IDE), and **agent**
+- Reconstructed builds with time, project, duration, peak RSS, status, source, and agent
 - Filter by project and time range
-- Per-build detail with resource peaks and a captured log excerpt
+- Detail view with resource peaks and a log excerpt
 
 ### Settings
-- Configurable **history retention** (default **15 days**, range 1–90). Lowering it purges out-of-range entries immediately.
+
+- History retention (default 15 days, range 1–90). Lowering it deletes older entries right away.
 
 ### Headless collection
 
-Daemonitor can keep collecting in the background without the desktop window. Use the toolbar action
-to switch from desktop to headless mode, or start it directly with `--headless`. Packaged headless
-mode uses the same local database and settings as the desktop app, shows a system tray/menu-bar icon
-when the OS supports it, and offers **Open Daemonitor** and **Quit Daemonitor** actions from that
-menu.
+Keep collecting without the desktop window via the toolbar or `--headless`. Same local database and
+settings as the desktop app. On supported OSes, a tray/menu-bar icon offers **Open Daemonitor** and
+**Quit Daemonitor**.
 
 ### MCP access
 
-Daemonitor can also run as a local, read-only MCP server so agent tools can inspect retained build
-history and currently visible Gradle-related processes. The MCP mode uses stdio, reads the same local
-SQLite database as the desktop app, and exposes these tools:
+Optional local, read-only MCP server so agent tools can inspect retained history and current
+Gradle-related processes. Same SQLite database as the desktop app. Tools:
 
-- `daemonitor_search_history`: search retained builds by id, command, project, status, source, or agent.
-- `daemonitor_builds_for_process`: find retained builds and process samples for a daemon PID or process text.
-- `daemonitor_current_processes`: return the Gradle-related processes visible right now.
+- `daemonitor_search_history` — search builds by id, command, project, status, source, or agent
+- `daemonitor_builds_for_process` — builds and samples for a daemon PID or process text
+- `daemonitor_current_processes` — Gradle-related processes visible right now
 
-### AI-agent attribution
-Daemonitor fingerprints the coding agent behind a build from the environment-variable *names* the
-daemon recorded (names only — never values, staying within the redaction posture). It recognizes
-Claude Code, Cursor, Codex, Gemini CLI, and Aider, and flags unrecognized agents explicitly.
+### Agent attribution
 
-It also **subtracts its own ambient environment** before attributing: if Daemonitor itself runs
-inside, say, a Claude Code shell, every build would otherwise inherit those variables. Only signals
-that distinguish a build from Daemonitor's own session are attributed, so you don't get "everything
-is Claude."
+Daemonitor guesses the coding agent from environment-variable *names* in the daemon log (never
+values). It knows Claude Code, Cursor, Codex, Gemini CLI, and Aider, and marks unknown agents
+explicitly.
+
+It also ignores its own ambient environment. If Daemonitor is running inside Claude Code, those
+variables are not treated as proof that every build came from Claude.
 
 ---
 
 ## Requirements
 
-- **JDK 17+** to run Gradle from source. The build uses a Java 21 toolchain, which Gradle
-  auto-provisions when a local Java 21 installation is unavailable.
+- **JDK 17+** to run Gradle from source (the build uses a Java 21 toolchain; Gradle can provision it)
 - macOS, Linux, or Windows
-- Permission to read your own process list and Gradle daemon logs
-
-Daemonitor reads Gradle daemon logs under `~/.gradle/daemon/<version>/` and enumerates processes
-owned by the current user.
+- Permission to read your own process list and Gradle daemon logs under `~/.gradle/daemon/<version>/`
 
 ## Install
-
-Daemonitor is distributed as a native desktop app per operating system:
 
 | OS | First-time installer | In-app update package |
 |----|----------------------|------------------------|
@@ -112,56 +95,48 @@ Daemonitor is distributed as a native desktop app per operating system:
 | Windows | `.msi` | `.zip` app directory |
 | Linux | `.deb` | `.tar.gz` standalone image |
 
-Release asset names include the CPU architecture (`x64` or `arm64`), for example
-`Daemonitor-1.0.7-macos-arm64.dmg` and `Daemonitor-1.0.7-macos-arm64.zip`.
+Release asset names include the CPU architecture (`x64` or `arm64`), e.g.
+`Daemonitor-1.0.7-macos-arm64.dmg`.
 
-The installed app does not require a project-local Gradle setup. It only reads local process
-metadata and Gradle daemon logs for the current user.
+No project-local Gradle setup is required. The app only reads process metadata and daemon logs for
+the current user.
 
-Linux distribution starts with the GitHub Releases `.deb` for package installs and a `.tar.gz`
-update package for writable standalone installs. Package-managed Linux prompts stay advisory; see
+On Linux, prefer the GitHub Releases `.deb` for installs and `.tar.gz` for writable standalone
+updates. Package-managed prompts stay advisory; see
 [Linux Update Distribution](docs/linux-update-distribution.md).
 
 ## Updates
 
-Daemonitor checks GitHub Releases once at startup and marks the Settings tab as `Settings (1)` when
-a newer version is available. The Settings tab can also check manually. When a newer release is
-available, Daemonitor selects the matching artifact for the current operating system and CPU
-architecture only after you approve the download, verifies the SHA-256 checksum from release
-metadata, and either stages an update package for **Restart and Update** or opens the platform
-installer when automatic installation is not supported for the current install. The app does not
-silently install updates while it is running.
+Daemonitor checks GitHub Releases once at startup and marks Settings with `(1)` when a newer version
+exists. You can also check manually from Settings. After you approve a download, it picks the
+matching artifact for your OS and arch, verifies the SHA-256 checksum, then either stages a
+**Restart and Update** package or opens the platform installer. It does not install updates silently
+while running.
 
 ## Run from source
-
-Source builds require **JDK 17+** to launch Gradle; the pinned Java 21 toolchain is provisioned
-automatically when it is not installed locally.
 
 ```bash
 ./gradlew run
 ```
 
-To collect and persist data without starting Compose or requiring a display server:
+Headless (no Compose / display):
 
 ```bash
 ./gradlew runHeadless
 ```
 
-Packaged launchers also accept `--headless`. Headless and desktop modes use the same local database
-and retention setting. On desktop operating systems, the tray/menu-bar icon can reopen Daemonitor or
-quit the collector. Stop source-run headless mode with `Ctrl+C` or the service manager's normal
-termination signal.
+Packaged launchers also accept `--headless`. Desktop and headless share the database and retention
+setting. Stop a source-run headless process with `Ctrl+C`.
 
 ## Connect MCP
 
-Daemonitor exposes read-only MCP from the desktop app:
+From the desktop app:
 
-1. Open Daemonitor.
-2. Go to Settings.
-3. Enable MCP.
-4. Copy the local URL and token shown in Settings into your MCP client.
+1. Open Daemonitor → Settings
+2. Enable MCP
+3. Copy the local URL and token into your MCP client
 
-Example HTTP MCP client config:
+Example HTTP config:
 
 ```json
 {
@@ -176,17 +151,12 @@ Example HTTP MCP client config:
 }
 ```
 
-The in-app MCP server binds only to `127.0.0.1` and requires the token shown in Settings. Keep
-Daemonitor open while your MCP client is connected. It is read-only: it can search Daemonitor's
-retained SQL history and poll current Gradle-related processes, but it does not start, stop, or
-modify builds.
+The server binds to `127.0.0.1` only and needs the Settings token. Keep Daemonitor open while
+connected. It is read-only — it does not start, stop, or change builds.
 
-Clients that only support stdio can still start Daemonitor through the native packaged launcher with
-the `--mcp` argument. Do not point a stdio MCP client at `./gradlew run`; Gradle writes its own
-progress output to stdout, which can corrupt stdio MCP messages. For local development, build a
-distributable first and use the launcher inside `build/compose/binaries/main/app/`.
-
-Example stdio MCP client config:
+For stdio clients, use the packaged launcher with `--mcp`. Do not point a stdio client at
+`./gradlew run`; Gradle's own stdout will corrupt MCP messages. For local development, package first
+and use the launcher under `build/compose/binaries/main/app/`.
 
 ```json
 {
@@ -199,13 +169,11 @@ Example stdio MCP client config:
 }
 ```
 
-Replace `command` with the installed launcher path for your operating system. The stdio server exits
-when the client disconnects.
+Replace `command` with your install path. The stdio server exits when the client disconnects.
 
 ## Build a native distribution
 
-The Compose Gradle plugin packages a platform-native installer via `jpackage` (must be built on the
-target OS):
+Build on the target OS:
 
 ```bash
 ./gradlew packageDmg          # macOS (.dmg)
@@ -213,16 +181,15 @@ target OS):
 ./gradlew packageDeb          # Linux (.deb)
 ```
 
-Mac App Store packaging experiments use a separate distribution channel (see
-[`docs/mac-app-store-distribution.md`](docs/mac-app-store-distribution.md)):
+Mac App Store experiments use a separate channel (see
+[docs/mac-app-store-distribution.md](docs/mac-app-store-distribution.md)):
 
 ```bash
 ./gradlew packagePkg -Pdaemonitor.distribution=APP_STORE
 ```
 
-Tag-triggered GitHub releases also publish `latest.json`, `update.json`, and `checksums.txt` next
-to the native installers. The updater-facing metadata contract is documented in
-[`docs/update-metadata.md`](docs/update-metadata.md).
+Tag-triggered releases also publish `latest.json`, `update.json`, and `checksums.txt`. See
+[docs/update-metadata.md](docs/update-metadata.md).
 
 ## Test
 
@@ -230,35 +197,35 @@ to the native installers. The updater-facing metadata contract is documented in
 ./gradlew test
 ```
 
-The suite includes unit tests for the collection/classification/aggregation logic and **Compose UI
-tests** that mount the real screens and assert on rendered nodes. CI runs the full suite on
-**Linux, Windows, and macOS** (Linux uses a virtual display for the UI tests).
+Unit tests cover collection, classification, and aggregation. Compose UI tests mount the real
+screens. CI runs on Linux, Windows, and macOS (Linux uses a virtual display for UI tests).
 
 ### Updating README screenshots
 
-The checked-in screenshots are rendered from synthetic, privacy-safe sample state using the real
-Compose screens at the application's native 1180×760 window size. After a visible UI change, run:
+Screenshots are rendered from synthetic sample state at the app's 1180×760 window size. After a UI
+change:
 
 ```bash
 ./gradlew captureReadmeScreenshots test
 ```
 
-Review the files in `docs/images/` before committing. Keep sample paths and logs synthetic; never
-capture a locally running instance with personal paths, environment values, or command-line secrets.
+Review `docs/images/` before committing. Keep samples synthetic — don't capture a live session with
+personal paths or secrets.
 
 ---
 
 ## How it works
 
-Daemonitor combines two signals:
+Two signals:
 
-1. **Process polling** (via [OSHI](https://github.com/oshi/oshi)) every 2 s — RSS, CPU, uptime, and JVM flags for the current user's Gradle-related JVMs.
-2. **Daemon-log parsing** — build *existence*, start/end, outcome, working directory, and the environment-variable names used for source/agent attribution.
+1. **Process polling** ([OSHI](https://github.com/oshi/oshi), every 2s) — RSS, CPU, uptime, and JVM
+   flags for your Gradle-related JVMs.
+2. **Daemon-log parsing** — build start/end, outcome, working directory, and env-var names for
+   source/agent attribution.
 
-A build is reconstructed by correlating a daemon's busy→idle bracket (which must contain a real build
-start) with the resource samples taken inside that window. Confirmed builds and samples are persisted
-to a local SQLite database (owner-only file permissions; excluded from Time Machine on macOS) and
-purged by the configured retention window.
+A build is reconstructed by matching a daemon's busy→idle window (with a real build start inside it)
+to resource samples in that window. Confirmed builds go to a local SQLite database (owner-only
+permissions; excluded from Time Machine on macOS) and are purged by the retention setting.
 
 ### Where data lives
 
@@ -268,20 +235,18 @@ purged by the configured retention window.
 | Linux | `$XDG_DATA_HOME/Daemonitor` (or `~/.local/share/Daemonitor`) |
 | Windows | `%LOCALAPPDATA%\Daemonitor` |
 
-Holds `watcher.db` (history) and `settings.properties` (retention).
+Contains `watcher.db` (history) and `settings.properties` (retention).
 
 ## Tech stack
 
-Kotlin · Compose for Desktop (Material 3) · OSHI · SQLDelight + JDBC SQLite · Kotlin Coroutines.
+Kotlin · Compose for Desktop (Material 3) · OSHI · SQLDelight + JDBC SQLite · Kotlin Coroutines
 
 ## Privacy
 
-All data is local. Command lines and daemon-log lines may contain sensitive values, so they are
-redacted on a best-effort basis before storage, and the database file is created with owner-only
-permissions. Daemonitor only makes outbound requests for GitHub Releases update checks at startup or
-from Settings, and for installer downloads that you explicitly approve.
+Everything is local. Command lines and daemon-log lines are redacted before storage; the database is
+owner-only. Outbound requests are limited to GitHub Releases update checks and downloads you
+approve.
 
 ## Status
 
-Early (v1.0.7). The data model and detection heuristics are evolving; see `requirements.md` for the
-original specification.
+Early (v1.0.7). Heuristics are still evolving; see `requirements.md` for the original spec.

--- a/docs/linux-update-distribution.md
+++ b/docs/linux-update-distribution.md
@@ -2,109 +2,91 @@
 
 ## Decision
 
-Daemonitor will keep the initial Linux release path as a direct `.deb` asset on GitHub Releases,
-plus a `.tar.gz` update package for standalone installations that can safely self-update. After
-that flow is working, Linux package updates should move to a signed apt repository as the preferred
-distribution channel for package-managed installs.
+Ship Linux first as a GitHub Releases `.deb`, plus a `.tar.gz` for standalone installs that can
+self-update. Longer term, prefer a signed apt repository for package-managed installs.
 
-The app must not try to self-install updates on Linux installations owned by the system package
-manager. Package-managed Linux update prompts should describe the available version and send the
-user to the appropriate system-managed install path:
+Never self-install updates into a package-manager-owned install. Prompts should describe the new
+version and point people at the right path:
 
-- If the current install came from the apt repository, prompt the user to update through their
-  package manager.
-- If the current install came from a downloaded `.deb`, prompt the user to download and open the
-  newer GitHub Releases `.deb`.
-- If the current install is a writable standalone / archive layout, Daemonitor may download the
-  matching `.tar.gz` update package, stage it, and apply it after **Restart and Update**.
-- If the install source is unknown, offer the manual package path and explain that apt is preferred
-  once the repository is configured.
+- **apt install** → update via the system package manager
+- **downloaded `.deb`** → download and open the newer GitHub Releases `.deb`
+- **writable standalone / archive** → download the matching `.tar.gz`, stage it, apply after
+  **Restart and Update**
+- **unknown** → offer the manual package path; prefer apt once a repo is available
 
-This keeps package-manager installs independent from repository setup and avoids silent privilege
-escalation or unsafe replacement of files owned by `dpkg`/`rpm` from inside the desktop app.
+That keeps package-manager installs separate from repo setup and avoids privilege escalation or
+replacing `dpkg`/`rpm`-owned files from inside the app.
 
-## Direct `.deb` Download
+## Direct `.deb` download
 
-Direct `.deb` downloads are the smallest viable Linux distribution path:
+Smallest viable path:
 
-- GitHub Releases already publishes `Daemonitor-<version>-linux-<arch>.deb`.
-- Users can download and open the package with their desktop software installer, or install it with
-  a terminal command such as `sudo apt install ./Daemonitor-<version>-linux-<arch>.deb`.
-- The release asset can be produced by the current `packageDeb` CI path without repository metadata.
+- Releases already publish `Daemonitor-<version>-linux-<arch>.deb`
+- Users open it in the desktop installer, or run
+  `sudo apt install ./Daemonitor-<version>-linux-<arch>.deb`
+- Built by the existing `packageDeb` CI job; no repository metadata required
 
-The tradeoff is that direct `.deb` installs do not provide a standard update feed. The app can detect
-and announce a new release, but installation still requires explicit user action and system package
-manager privileges.
+Tradeoff: no standard update feed. The app can announce a release, but install still needs an
+explicit user action and package-manager privileges.
 
-## Apt Repository
+## Apt repository
 
-An apt repository should be the long-term Linux update channel because it gives users normal package
-manager behavior:
+Preferred long-term channel for package-managed installs:
 
-- Version discovery and upgrades happen through `apt update` and `apt upgrade`.
-- Dependency checks, package replacement, and removal stay owned by the operating system.
-- The app does not need to invoke privileged commands or ship an updater daemon.
+- Upgrades via `apt update` / `apt upgrade`
+- Dependency checks and replacement stay with the OS
+- The app does not need privileged commands or an updater daemon
 
-The apt repository is not required before shipping the Phase 1 updater prompt. It becomes the
-preferred path once repository hosting, package metadata, and signing are in place.
+Not required for the Phase 1 advisory prompt. Prefer apt once hosting, metadata, and signing exist.
 
-## Update Prompt Behavior
+## Update prompt behavior
 
-Linux package-managed prompts must be advisory, not self-installing:
+Package-managed prompts are advisory only:
 
-- Show the available version and release link.
-- Never run `sudo`, `pkexec`, `apt`, `dpkg`, or any privileged installer command from the app.
-- For apt installs, say to update from the system package manager and link to repository setup docs.
-- For direct `.deb` installs, the app may download and verify the GitHub Releases `.deb`, then open
-  it with the OS package installer so the operating system owns privilege prompts.
-- For writable standalone installs, the app may stage the `.tar.gz` update package and apply it only
-  after the user chooses **Restart and Update**.
-- Allow dismissing or deferring the prompt so background collection is not blocked.
+- Show the available version and release link
+- Never run `sudo`, `pkexec`, `apt`, `dpkg`, or other privileged installers from the app
+- apt installs → tell the user to update via the package manager (link repo setup docs)
+- direct `.deb` → may download and verify the GitHub asset, then open it with the OS installer
+- standalone → may stage `.tar.gz` and apply only after **Restart and Update**
+- Allow dismiss / defer so background collection is not blocked
 
-## Package Metadata Requirements
+## Package metadata
 
-Before apt publication, the Linux package metadata needs to be stable enough for package manager
-upgrades:
+Before apt publication, keep metadata stable:
 
 - Package name: `daemonitor`
 - Display name: `Daemonitor`
-- Version: same release version used by GitHub Releases
-- Architecture: the architecture produced by the Linux package job
-- Maintainer: project maintainer contact for package metadata
-- Description: concise desktop-app description plus a longer package description
+- Version: same as GitHub Releases
+- Architecture: from the Linux package job
+- Maintainer: project maintainer contact
+- Description: short desktop blurb plus a longer package description
 - Homepage: `https://github.com/cdsap/daemonitor`
 - License: MIT
-- Dependencies: explicit runtime dependencies required by the generated package
-- Conflicts/Replaces/Provides: only if the package name or install layout changes later
+- Dependencies: explicit runtime deps for the generated package
+- Conflicts/Replaces/Provides: only if the name or layout changes later
 
-The repository also needs a deterministic asset naming convention that maps one Git tag to one
-package version and one apt package entry.
+Map one Git tag → one package version → one apt package entry.
 
-## Hosting And Signing Requirements
+## Hosting and signing
 
-The apt repository needs:
+The apt repo needs:
 
-- A repository host reachable over HTTPS.
-- A `dists/` and `pool/` layout, or an equivalent static repository generated by tooling such as
-  `reprepro` or `aptly`.
-- `Packages` and compressed `Packages` indexes for the supported distribution/component.
-- A signed `Release` or `InRelease` file.
-- A public signing key and documented setup command for users.
-- A private signing key managed only in release infrastructure, never in the app or repository.
-- CI or release automation that uploads the `.deb`, regenerates indexes, signs metadata, and verifies
-  that `apt update` can read the repository.
+- HTTPS host
+- `dists/` + `pool/` (or equivalent via `reprepro` / `aptly`)
+- `Packages` indexes (plain and compressed)
+- Signed `Release` / `InRelease`
+- Public signing key + documented user setup
+- Private signing key only in release infra (never in the app or this repo)
+- Automation to upload the `.deb`, regenerate indexes, sign, and verify `apt update`
 
-GitHub Pages or another static HTTPS host can serve the repository if release automation can update
-the repository files without exposing the signing key.
+GitHub Pages or another static HTTPS host works if automation can update repo files without exposing
+the signing key.
 
-## Follow-up Implementation Plan
+## Follow-up
 
-1. Keep publishing the direct GitHub Releases `.deb` in Phase 1.
-2. Add Linux update prompt copy that distinguishes apt, direct `.deb`, and unknown install sources
-   without attempting privileged installation.
-3. Choose repository hosting and signing-key storage for the apt repository.
-4. Add release automation to generate apt metadata from the published `.deb`.
-5. Add a validation job that installs the repository key/source in a clean Linux runner, runs
-   `apt update`, and verifies the expected `daemonitor` version is available.
-6. Update install docs to prefer apt once the repository is live, while retaining direct `.deb` as a
-   fallback.
+1. Keep publishing the GitHub Releases `.deb` in Phase 1
+2. Prompt copy that distinguishes apt, direct `.deb`, and unknown — no privileged install
+3. Choose hosting and signing-key storage
+4. Automate apt metadata from the published `.deb`
+5. CI: install the repo key/source on a clean Linux runner, `apt update`, confirm `daemonitor`
+6. Prefer apt in install docs once live; keep direct `.deb` as fallback

--- a/docs/linux-update-distribution.md
+++ b/docs/linux-update-distribution.md
@@ -2,20 +2,24 @@
 
 ## Decision
 
-Ship Linux first as a GitHub Releases `.deb`, plus a `.tar.gz` for standalone installs that can
-self-update. Longer term, prefer a signed apt repository for package-managed installs.
+Daemonitor will keep the initial Linux release path as a direct `.deb` asset on GitHub Releases,
+plus a `.tar.gz` update package for standalone installs that can self-update. Longer term, Linux
+package updates should move to a signed apt repository as the preferred channel for package-managed
+installs.
 
-Never self-install updates into a package-manager-owned install. Prompts should describe the new
-version and point people at the right path:
+The app must not try to self-install updates on Linux installations owned by the system package
+manager. Prompts should describe the available version and point people at the right path:
 
-- **apt install** → update via the system package manager
-- **downloaded `.deb`** → download and open the newer GitHub Releases `.deb`
-- **writable standalone / archive** → download the matching `.tar.gz`, stage it, apply after
-  **Restart and Update**
-- **unknown** → offer the manual package path; prefer apt once a repo is available
+- If the current install came from the apt repository, update through the system package manager.
+- If the current install came from a downloaded `.deb`, download and open the newer GitHub Releases
+  `.deb`.
+- If the current install is a writable standalone / archive layout, Daemonitor may download the
+  matching `.tar.gz`, stage it, and apply it after **Restart and Update**.
+- If the install source is unknown, offer the manual package path and note that apt is preferred
+  once a repository is configured.
 
-That keeps package-manager installs separate from repo setup and avoids privilege escalation or
-replacing `dpkg`/`rpm`-owned files from inside the app.
+That keeps package-manager installs separate from repository setup and avoids privilege escalation
+or replacing `dpkg`/`rpm`-owned files from inside the app.
 
 ## Direct `.deb` download
 
@@ -37,7 +41,8 @@ Preferred long-term channel for package-managed installs:
 - Dependency checks and replacement stay with the OS
 - The app does not need privileged commands or an updater daemon
 
-Not required for the Phase 1 advisory prompt. Prefer apt once hosting, metadata, and signing exist.
+The apt repository is not required before shipping the Phase 1 updater prompt. Prefer apt once
+hosting, metadata, and signing exist.
 
 ## Update prompt behavior
 
@@ -74,9 +79,9 @@ The apt repo needs:
 - HTTPS host
 - `dists/` + `pool/` (or equivalent via `reprepro` / `aptly`)
 - `Packages` indexes (plain and compressed)
-- Signed `Release` / `InRelease`
+- A signed `Release` or `InRelease` file
 - Public signing key + documented user setup
-- Private signing key only in release infra (never in the app or this repo)
+- A private signing key managed only in release infrastructure, never in the app or this repo
 - Automation to upload the `.deb`, regenerate indexes, sign, and verify `apt update`
 
 GitHub Pages or another static HTTPS host works if automation can update repo files without exposing

--- a/docs/update-metadata.md
+++ b/docs/update-metadata.md
@@ -1,22 +1,19 @@
 # Update Metadata Contract
 
-Daemonitor publishes update metadata to each tag-triggered GitHub Release so updater clients can
-validate release information and native downloads before staging or opening installers. The desktop
-app uses this metadata to download the selected artifact in-app, verify it, and either stage an
-automatic **Restart and Update** package or hand off to the operating system installer.
+Each tag-triggered GitHub Release publishes metadata so clients can check version info and verify
+downloads before staging or opening installers. The desktop app uses that to fetch the right
+artifact, verify it, then either stage **Restart and Update** or hand off to the OS installer.
 
 ## Release assets
 
-Each release includes these machine-readable files:
+Machine-readable files on each release:
 
-- `latest.json`: canonical metadata for the current release.
-- `update.json`: an alias with the same content for updater clients that prefer an update-specific
-  file name.
-- `checksums.txt`: SHA-256 checksums for every native installer and update package, in the common
-  `<sha256>  <fileName>` format.
-- `<asset>.sha256`: per-asset SHA-256 sidecars for the in-app updater and manual verification.
+- `latest.json` — metadata for the current release
+- `update.json` — same content, alternate name for some clients
+- `checksums.txt` — SHA-256 lines in `<sha256>  <fileName>` form
+- `<asset>.sha256` — per-asset sidecars for the in-app updater and manual checks
 
-The release also includes platform/architecture native installers and update packages:
+Native installers and update packages:
 
 ### Installers (first-time / manual)
 
@@ -68,31 +65,27 @@ are used for installer names, update package names, and metadata.
 }
 ```
 
-Clients should treat `schemaVersion`, `version`, `tag`, and `assets` as required. Each asset entry
-must include `platform`, `fileName`, `url`, `sha256`, and `size`. Schema `2` also includes `arch`
-(`x64` / `arm64`) and `role` (`update` / `installer`).
+Clients should treat `schemaVersion`, `version`, `tag`, and `assets` as required. Each asset needs
+`platform`, `fileName`, `url`, `sha256`, and `size`. Schema `2` also has `arch` (`x64` / `arm64`)
+and `role` (`update` / `installer`).
 
-Schema `1` metadata without `arch`/`role` remains readable: clients infer role from the file
-extension and treat missing architecture as a legacy fallback for the current OS.
+Schema `1` without `arch`/`role` is still readable: infer role from the file extension, and treat
+missing arch as a legacy fallback for the current OS.
 
 ## Client validation
 
-Updater clients should:
-
 1. Download `latest.json` or `update.json` from the GitHub Release.
-2. Confirm `schemaVersion` is supported (`1` or `2`).
-3. Detect the current operating system and CPU architecture.
-4. Select the asset matching the current platform and architecture.
-5. Prefer `role=update` packages when the installation supports automatic Restart and Update.
-6. Prefer `role=installer` assets when automatic installation is unavailable.
-7. Download the asset from `url` only from the official `cdsap/daemonitor` GitHub repository.
-8. Compute SHA-256 over the downloaded bytes and compare it with `sha256`.
-9. Stage validated update packages without terminating Daemonitor, or open verified installers only
-   after the user approves the update.
-10. Apply staged updates only after the user chooses **Restart and Update**.
+2. Confirm `schemaVersion` is `1` or `2`.
+3. Detect the current OS and CPU architecture.
+4. Pick the asset for that platform and arch.
+5. Prefer `role=update` when Restart and Update is supported; otherwise prefer `role=installer`.
+6. Download only from the official `cdsap/daemonitor` repository URL.
+7. Verify SHA-256 against `sha256`.
+8. Stage update packages without quitting Daemonitor, or open verified installers only after the
+   user approves.
+9. Apply staged updates only after **Restart and Update**.
 
-Clients may also download `checksums.txt` or `<asset>.sha256` and compare them against the JSON
-asset list as a secondary integrity check.
+Optional: cross-check `checksums.txt` or `<asset>.sha256` against the JSON list.
 
-A release is not eligible for automatic updates on a given machine when the required
-platform/architecture update package is missing.
+Automatic updates are unavailable on a machine when the matching platform/arch update package is
+missing from the release.

--- a/requirements.md
+++ b/requirements.md
@@ -2,12 +2,14 @@
 
 ## Overview
 
-Build activity is becoming harder to track during agentic AI workflows. Developers may have multiple IDEs, terminals, agents, and background tasks triggering Gradle builds at the same time. The goal of this project is to build a local Gradle Process Watcher that helps developers understand what Gradle activity is currently happening on their laptop and what happened recently.
+When several IDEs, terminals, agents, and scripts can all start Gradle builds, it's easy to lose
+track of what is running on a laptop and what ran earlier. This project is a local Gradle process
+watcher for that case.
 
-The application should provide a Compose UI with two main views:
+The app should use Compose with two main views:
 
-1. **Live Monitor**, focused on currently running Gradle processes.
-2. **Historical View**, focused on past Gradle activity and resource usage.
+1. **Live Monitor** — currently running Gradle processes.
+2. **Historical View** — past Gradle activity and resource usage.
 
 ## Goals
 


### PR DESCRIPTION
## Summary

Rewrites the README and a few user-facing docs so they read like a person wrote them: shorter sentences, less marketing jargon, fewer bold/italic flourishes. Feature coverage (live/visual/history, headless, MCP, updates, privacy) is unchanged — only the voice and redundancy.

Also lightly cleaned `requirements.md` overview, Linux update distribution notes, and the update-metadata contract.

## Test plan

- [ ] Skim README on GitHub for broken image links and section flow
- [ ] Spot-check linked docs (`linux-update-distribution`, `update-metadata`, `mac-app-store-distribution`) still resolve
