### PR TITLE
fix: refactor defaultdaemonitorqueryservice to depend on persistence por

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
@@ -69,7 +69,8 @@ class AppContainer(
         currentProcessesProvider: () -> List<GradleProcess> = processCollector::poll,
     ): DaemonitorMcpServer = DaemonitorMcpServer(
         DefaultDaemonitorQueryService(
-            database = database,
+            builds = database,
+            samples = database,
             processSource = ProcessSource { currentProcessesProvider() },
         ),
     )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/DaemonitorMcpStdio.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/DaemonitorMcpStdio.kt
@@ -18,7 +18,7 @@ object DaemonitorMcpStdio {
         output: OutputStream = System.out,
     ) {
         database.use {
-            val server = DaemonitorMcpServer(DefaultDaemonitorQueryService(it, processSource))
+            val server = DaemonitorMcpServer(DefaultDaemonitorQueryService(it, it, processSource))
             McpMessageStream(input, output).serve(server)
         }
     }

--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryService.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryService.kt
@@ -2,31 +2,33 @@ package io.github.cdsap.daemonitor.application
 
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
-import io.github.cdsap.daemonitor.store.WatcherDatabase
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
 
 /**
  * Query service backed by persistence reads and a [ProcessSource].
  * Keeps MCP free of SQLite and OSHI collection details.
  */
 class DefaultDaemonitorQueryService(
-    private val database: WatcherDatabase,
+    private val builds: BuildRepository,
+    private val samples: ProcessSampleRepository,
     private val processSource: ProcessSource,
 ) : DaemonitorQueryService {
     override fun searchHistory(query: String, limit: Int): List<Build> =
-        database.searchBuilds(query, limit.coerceQueryLimit())
+        builds.search(query, limit.coerceQueryLimit())
 
     override fun buildsForProcess(process: String, limit: Int): ProcessBuildResult {
         val safeLimit = limit.coerceQueryLimit()
         val pid = process.toLongOrNull()
-        val builds = if (pid != null) {
-            database.buildsForDaemonPid(pid, safeLimit)
+        val matchedBuilds = if (pid != null) {
+            builds.findByDaemon(pid, safeLimit)
         } else {
-            database.searchBuilds(process, safeLimit)
+            builds.search(process, safeLimit)
         }
-        val samples = if (pid != null) {
-            database.processSamplesForPid(pid, safeLimit)
+        val matchedSamples = if (pid != null) {
+            samples.findByPid(pid, safeLimit)
         } else {
-            database.recentProcessSamples(TEXT_MATCH_SAMPLE_SCAN_LIMIT).filter { sample ->
+            samples.recentSamples(TEXT_MATCH_SAMPLE_SCAN_LIMIT).filter { sample ->
                 sample.commandLine.contains(process, ignoreCase = true) ||
                     sample.workingDirectory?.contains(process, ignoreCase = true) == true ||
                     sample.projectPath?.contains(process, ignoreCase = true) == true ||
@@ -35,8 +37,8 @@ class DefaultDaemonitorQueryService(
         }
         return ProcessBuildResult(
             process = process,
-            matchedBuilds = builds,
-            matchedProcessSamples = samples,
+            matchedBuilds = matchedBuilds,
+            matchedProcessSamples = matchedSamples,
         )
     }
 

--- a/src/test/kotlin/io/github/cdsap/daemonitor/McpServiceControllerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/McpServiceControllerTest.kt
@@ -22,7 +22,7 @@ class McpServiceControllerTest {
                     port = port,
                     token = token,
                     server = DaemonitorMcpServer(
-                        DefaultDaemonitorQueryService(database, ProcessSource { emptyList() }),
+                        DefaultDaemonitorQueryService(database, database, ProcessSource { emptyList() }),
                     ),
                 )
             }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -184,7 +184,7 @@ class WatcherServiceTest {
         pollAction = pollAction,
         updateService = updateService,
         mcpServerFactory = {
-            DaemonitorMcpServer(DefaultDaemonitorQueryService(database, ProcessSource { emptyList() }))
+            DaemonitorMcpServer(DefaultDaemonitorQueryService(database, database, ProcessSource { emptyList() }))
         },
         uiDispatcher = uiDispatcher,
         ioDispatcher = uiDispatcher,

--- a/src/test/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryServiceTest.kt
@@ -5,50 +5,48 @@ import io.github.cdsap.daemonitor.domain.model.FinalStatus
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.domain.model.ProcessType
 import io.github.cdsap.daemonitor.domain.model.Source
-import io.github.cdsap.daemonitor.store.WatcherDatabase
-import org.junit.jupiter.api.io.TempDir
-import java.nio.file.Path
+import io.github.cdsap.daemonitor.persistence.BuildRepository
+import io.github.cdsap.daemonitor.persistence.ProcessSample
+import io.github.cdsap.daemonitor.persistence.ProcessSampleRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DefaultDaemonitorQueryServiceTest {
 
     @Test
-    fun `searchHistory delegates to retained builds`(@TempDir tmp: Path) {
-        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("old", 1_000, project = "/repo/a"))
-        db.insertBuild(build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED))
-        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+    fun `searchHistory delegates to retained builds`() {
+        val builds = FakeBuildRepository(
+            listOf(
+                build("old", 1_000, project = "/repo/a"),
+                build("match", 2_000, project = "/repo/target", status = FinalStatus.FAILED),
+            ),
+        )
+        val queries = DefaultDaemonitorQueryService(builds, FakeProcessSampleRepository(), ProcessSource { emptyList() })
 
-        val builds = queries.searchHistory("target", limit = 50)
+        val result = queries.searchHistory("target", limit = 50)
 
-        assertEquals(listOf("match"), builds.map { it.buildId })
-        assertEquals(FinalStatus.FAILED, builds.single().finalStatus)
+        assertEquals(listOf("match"), result.map { it.buildId })
+        assertEquals(FinalStatus.FAILED, result.single().finalStatus)
     }
 
     @Test
-    fun `buildsForProcess matches pid builds and samples`(@TempDir tmp: Path) {
-        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("b1", 3_000, pid = 42, project = "/repo/target"))
-        db.insertSample(
-            GradleProcess(
-                pid = 42,
-                parentPid = 7,
-                type = ProcessType.GRADLE_DAEMON,
-                commandLine = "java GradleDaemon",
-                workingDirectory = "/repo/target",
-                projectPath = "/repo/target",
-                cpuPercent = 12.0,
-                rssMemoryMb = 512,
-                maxHeapMb = 2048,
-                minHeapMb = null,
-                gc = "G1",
-                startTimeMs = 1_000,
-                status = "RUNNING",
+    fun `buildsForProcess matches pid builds and samples`() {
+        val builds = FakeBuildRepository(listOf(build("b1", 3_000, pid = 42, project = "/repo/target")))
+        val samples = FakeProcessSampleRepository(
+            listOf(
+                processSample(
+                    pid = 42,
+                    parentPid = 7,
+                    project = "/repo/target",
+                    timestampMs = 3_100,
+                    commandLine = "java GradleDaemon",
+                    cpuPercent = 12.0,
+                    rssMemoryMb = 512,
+                    maxHeapMb = 2048,
+                ),
             ),
-            timestampMs = 3_100,
         )
-        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+        val queries = DefaultDaemonitorQueryService(builds, samples, ProcessSource { emptyList() })
 
         val result = queries.buildsForProcess("42", limit = 50)
 
@@ -58,12 +56,15 @@ class DefaultDaemonitorQueryServiceTest {
     }
 
     @Test
-    fun `buildsForProcess text match filters recent samples`(@TempDir tmp: Path) {
-        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        db.insertBuild(build("keep", 4_000, project = "/repo/target"))
-        db.insertSample(sample(pid = 10, project = "/repo/target"), timestampMs = 4_100)
-        db.insertSample(sample(pid = 11, project = "/repo/other"), timestampMs = 4_200)
-        val queries = DefaultDaemonitorQueryService(db, ProcessSource { emptyList() })
+    fun `buildsForProcess text match filters recent samples`() {
+        val builds = FakeBuildRepository(listOf(build("keep", 4_000, project = "/repo/target")))
+        val samples = FakeProcessSampleRepository(
+            listOf(
+                processSample(pid = 10, project = "/repo/target", timestampMs = 4_100),
+                processSample(pid = 11, project = "/repo/other", timestampMs = 4_200),
+            ),
+        )
+        val queries = DefaultDaemonitorQueryService(builds, samples, ProcessSource { emptyList() })
 
         val result = queries.buildsForProcess("target", limit = 50)
 
@@ -72,10 +73,13 @@ class DefaultDaemonitorQueryServiceTest {
     }
 
     @Test
-    fun `currentProcesses uses process source`(@TempDir tmp: Path) {
-        val db = WatcherDatabase.open(tmp.resolve("watcher.db"))
-        val process = sample(pid = 99, project = "/repo", type = ProcessType.KOTLIN_DAEMON)
-        val queries = DefaultDaemonitorQueryService(db, ProcessSource { listOf(process) })
+    fun `currentProcesses uses process source`() {
+        val process = gradleProcess(pid = 99, project = "/repo", type = ProcessType.KOTLIN_DAEMON)
+        val queries = DefaultDaemonitorQueryService(
+            FakeBuildRepository(),
+            FakeProcessSampleRepository(),
+            ProcessSource { listOf(process) },
+        )
 
         assertEquals(listOf(99L), queries.currentProcesses().map { it.pid })
     }
@@ -106,7 +110,7 @@ class DefaultDaemonitorQueryServiceTest {
         agentProvider = null,
     )
 
-    private fun sample(
+    private fun gradleProcess(
         pid: Long,
         project: String,
         type: ProcessType = ProcessType.GRADLE_DAEMON,
@@ -125,4 +129,67 @@ class DefaultDaemonitorQueryServiceTest {
         startTimeMs = 1,
         status = "RUNNING",
     )
+
+    private fun processSample(
+        pid: Long,
+        project: String,
+        timestampMs: Long,
+        type: ProcessType = ProcessType.GRADLE_DAEMON,
+        commandLine: String = "java $type",
+        parentPid: Long = 1,
+        cpuPercent: Double? = 1.0,
+        rssMemoryMb: Long = 256,
+        maxHeapMb: Long? = 1024,
+    ) = ProcessSample(
+        timestampMs = timestampMs,
+        pid = pid,
+        parentPid = parentPid,
+        processType = type,
+        commandLine = commandLine,
+        workingDirectory = project,
+        projectPath = project,
+        cpuPercent = cpuPercent,
+        rssMemoryMb = rssMemoryMb,
+        maxHeapMb = maxHeapMb,
+        status = "RUNNING",
+    )
+
+    private class FakeBuildRepository(
+        private val stored: List<Build> = emptyList(),
+    ) : BuildRepository {
+        override fun save(build: Build) = error("not used")
+
+        override fun recent(): List<Build> = stored
+
+        override fun search(query: String, limit: Long): List<Build> {
+            val needle = query.trim()
+            if (needle.isEmpty()) return stored.take(limit.toInt())
+            return stored.filter { build ->
+                build.projectPath?.contains(needle, ignoreCase = true) == true ||
+                    build.workingDirectory?.contains(needle, ignoreCase = true) == true ||
+                    build.commandLine?.contains(needle, ignoreCase = true) == true ||
+                    build.buildId.contains(needle, ignoreCase = true)
+            }.take(limit.toInt())
+        }
+
+        override fun findByDaemon(pid: Long, limit: Long): List<Build> =
+            stored.filter { it.daemonPid == pid }.take(limit.toInt())
+
+        override fun distinctProjects(): List<String> = error("not used")
+    }
+
+    private class FakeProcessSampleRepository(
+        private val stored: List<ProcessSample> = emptyList(),
+    ) : ProcessSampleRepository {
+        override fun save(sample: GradleProcess, timestampMs: Long) = error("not used")
+
+        override fun samples(pid: Long, fromMs: Long, toMs: Long): List<Pair<Long, Double?>> =
+            error("not used")
+
+        override fun recentSamples(limit: Long): List<ProcessSample> =
+            stored.sortedByDescending { it.timestampMs }.take(limit.toInt())
+
+        override fun findByPid(pid: Long, limit: Long): List<ProcessSample> =
+            stored.filter { it.pid == pid }.take(limit.toInt())
+    }
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt
@@ -103,7 +103,7 @@ class DaemonitorMcpHttpServerTest {
     }
 
     private fun mcpServer(db: WatcherDatabase): DaemonitorMcpServer =
-        DaemonitorMcpServer(DefaultDaemonitorQueryService(db, ProcessSource { emptyList() }))
+        DaemonitorMcpServer(DefaultDaemonitorQueryService(db, db, ProcessSource { emptyList() }))
 
     private fun post(endpoint: String, token: String, body: String): HttpResponse<String> =
         request(endpoint, token = token, method = "POST", body = body)

--- a/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt
@@ -128,7 +128,8 @@ class DaemonitorMcpServerTest {
         database: WatcherDatabase,
         currentProcesses: List<GradleProcess>,
     ) = DefaultDaemonitorQueryService(
-        database = database,
+        builds = database,
+        samples = database,
         processSource = ProcessSource { currentProcesses },
     )
 


### PR DESCRIPTION
## Summary

### Problem

DefaultDaemonitorQueryService still takes concrete WatcherDatabase (SQLite/SQLDelight) even though persistence.BuildRepository and persistence.ProcessSampleRepository already expose the same read APIs (search/findByDaemon/recentSamples/findByPid), and WatcherDatabase already implements those ports. The class KDoc claims MCP stays free of SQLite details, but the constructor couples the application query use case to infrastructure.

### Why this matters

Every MCP/query test must open a real SQLite file, and future storage changes force edits through the application layer. PollMonitoring already uses ports correctly; this leaves an inconsistent, half-migrated boundary that makes query behavior harder to fake and easier to regress.

### Proposed change

Change DefaultDaemonitorQueryService to accept persistence.BuildRepository and persistence.ProcessSampleRepository (plus existing ProcessSource). Replace database.searchBuilds/buildsForDaemonPid/recentProcessSamples/processSamplesForPid with the port methods search/findByDaemon/recentSamples/findByPid. Keep AppContainer/DaemonitorMcpStdio passing WatcherDatabase as the adapter; update DefaultDaemonitorQueryServiceTest to inject fakes or typed ports.

### Notes

Clean-architecture incomplete migration: write polling already depends on application ports, but the read/query side still reaches through the SQLite adapter. Depending on persistence ports clarifies the application↔infrastructure boundary without a package reshuffle.

Fixes #120

## Changes

- `src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt`
- `src/main/kotlin/io/github/cdsap/daemonitor/DaemonitorMcpStdio.kt`
- `src/main/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryService.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/McpServiceControllerTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/application/DefaultDaemonitorQueryServiceTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpHttpServerTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/mcp/DaemonitorMcpServerTest.kt`

## Verification

- `./gradlew test`
