### PR TITLE
fix: refactor checkforupdate to receive build version explicitly

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/application/update/CheckForUpdate.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/application/update/CheckForUpdate.kt
@@ -1,12 +1,11 @@
 package io.github.cdsap.daemonitor.application.update
 
-import io.github.cdsap.daemonitor.BuildInfo
 import io.github.cdsap.daemonitor.update.UpdateCheckResult
 
 /** Checks whether a newer application release is available for the current install. */
 class CheckForUpdate(
     private val source: UpdateSource,
-    private val currentVersion: () -> String = { BuildInfo.current.version },
+    private val currentVersion: () -> String,
 ) {
     suspend operator fun invoke(): UpdateCheckResult = source.check(currentVersion())
 }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt
@@ -113,6 +113,7 @@ class WatcherServiceTest {
                         updateChecks += 1
                         UpdateCheckResult.UpToDate("1.0.3")
                     },
+                    currentVersion = { "1.0.3" },
                 ),
                 prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
                 applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),
@@ -170,6 +171,7 @@ class WatcherServiceTest {
         updateService: UpdateService = UpdateService(
             checkForUpdate = CheckForUpdate(
                 source = UpdateSource { UpdateCheckResult.UpToDate("1.0.3") },
+                currentVersion = { "1.0.3" },
             ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),

--- a/src/test/kotlin/io/github/cdsap/daemonitor/application/update/UpdateServiceTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/application/update/UpdateServiceTest.kt
@@ -49,7 +49,10 @@ class UpdateServiceTest {
         val candidate = candidate(installMode = UpdateInstallMode.Automatic)
         val staged = staged(candidate)
         val service = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(
                 UpdateInstaller { update, onProgress ->
                     assertEquals(candidate, update)
@@ -71,7 +74,10 @@ class UpdateServiceTest {
     @Test
     fun `prepare can return null for manual installer handoff`() = runTest {
         val service = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),
             urlOpener = UrlOpener {},
@@ -85,7 +91,10 @@ class UpdateServiceTest {
         val events = mutableListOf<String>()
         val staged = staged(candidate(installMode = UpdateInstallMode.Automatic))
         val service = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(
                 applier = UpdateApplier {
@@ -107,7 +116,10 @@ class UpdateServiceTest {
         var exited = 0
         val staged = staged(candidate(installMode = UpdateInstallMode.Automatic))
         val service = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(
                 applier = UpdateApplier { error("apply failed") },
@@ -124,7 +136,10 @@ class UpdateServiceTest {
     fun `open release url uses the injected opener`() {
         val opened = mutableListOf<String>()
         val service = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),
             urlOpener = UrlOpener { opened += it },

--- a/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt
@@ -158,7 +158,10 @@ class SettingsViewModelTest {
         val staged = stagedUpdate(candidate)
         val vm = SettingsViewModel(
             updateService = UpdateService(
-                checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+                checkForUpdate = CheckForUpdate(
+                    source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                    currentVersion = { "1.0.2" },
+                ),
                 prepareUpdate = PrepareUpdate(
                     UpdateInstaller { update, progress ->
                         progress(0.5)
@@ -193,7 +196,10 @@ class SettingsViewModelTest {
         val vm = SettingsViewModel(
             initial = SettingsUiState(updateState = UpdateUiState.ReadyToInstall(candidate, staged)),
             updateService = UpdateService(
-                checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+                checkForUpdate = CheckForUpdate(
+                    source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                    currentVersion = { "1.0.2" },
+                ),
                 prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
                 applyUpdate = ApplyUpdate(
                     applier = UpdateApplier { applied += it },
@@ -216,7 +222,10 @@ class SettingsViewModelTest {
         val candidate = candidate("Daemonitor-1.0.3-windows-x64.msi")
         val vm = SettingsViewModel(
             updateService = UpdateService(
-                checkForUpdate = CheckForUpdate(UpdateSource { UpdateCheckResult.UpToDate("1.0.2") }),
+                checkForUpdate = CheckForUpdate(
+                    source = UpdateSource { UpdateCheckResult.UpToDate("1.0.2") },
+                    currentVersion = { "1.0.2" },
+                ),
                 prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> error("No desktop") }),
                 applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),
                 urlOpener = UrlOpener {},
@@ -238,7 +247,10 @@ class SettingsViewModelTest {
         scope: TestScope,
     ): SettingsViewModel = SettingsViewModel(
         updateService = UpdateService(
-            checkForUpdate = CheckForUpdate(UpdateSource { result }),
+            checkForUpdate = CheckForUpdate(
+                source = UpdateSource { result },
+                currentVersion = { "1.0.2" },
+            ),
             prepareUpdate = PrepareUpdate(UpdateInstaller { _, _ -> null }),
             applyUpdate = ApplyUpdate(UpdateApplier {}, ProcessExiter {}),
             urlOpener = UrlOpener {},


### PR DESCRIPTION
## Summary

### Problem

`src/main/kotlin/io/github/cdsap/daemonitor/application/update/CheckForUpdate.kt:3` imports `BuildInfo`, and `CheckForUpdate.kt:9` defaults `currentVersion` to `BuildInfo.current.version`. That makes an application-layer use case know how packaged build metadata is loaded, even though `src/main/kotlin/io/github/cdsap/daemonitor/infrastructure/update/DefaultUpdateService.kt:31-33` already supplies the version from the composition/infrastructure boundary.

### Why this matters

The current default hides a runtime resource dependency inside a small use case. That increases coupling and makes tests or alternate update flows easier to accidentally bind to packaged application metadata instead of an injected version provider.

### Proposed change

Make `currentVersion` a required constructor dependency of `CheckForUpdate`, remove the `BuildInfo` import from that application-layer class, and keep `BuildInfo.current.version` wiring in `defaultUpdateService` / `updateServiceForDistribution`. Update existing tests that construct `CheckForUpdate` without `currentVersion` to pass a local version lambda.

### Notes

Clean architecture lens: `CheckForUpdate` is an application use case and should depend on the update source port plus explicit input, while packaged build metadata lookup belongs at the outer wiring boundary.

Fixes #125

## Changes

- `src/main/kotlin/io/github/cdsap/daemonitor/application/update/CheckForUpdate.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/WatcherServiceTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/application/update/UpdateServiceTest.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/ui/settings/SettingsViewModelTest.kt`

## Verification

- `./gradlew test`
