### PR TITLE
fix: refactor buildaggregator to inject log snippet limits

### DIFF
--- a/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt
@@ -36,6 +36,9 @@ class AppContainer(
     val buildAggregator = BuildAggregator(
         sampleProvider = database::samplesInWindow,
         ambientEnvNames = ambientEnvNames,
+        logSnippetLimit = with(MonitoringConfig.DEFAULT.logSnippetLimit) {
+            BuildAggregator.LogSnippetLimit(lines = lines, chars = chars)
+        },
     )
     val runtime = WatcherRuntime(
         collector = processCollector,

--- a/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt
@@ -8,6 +8,7 @@ import io.github.cdsap.daemonitor.application.ProcessSampleRepository
 import io.github.cdsap.daemonitor.collect.DaemonLog
 import io.github.cdsap.daemonitor.collect.DaemonLogWatcher
 import io.github.cdsap.daemonitor.collect.ProcessCollector
+import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.domain.BuildAggregator
 import io.github.cdsap.daemonitor.domain.model.GradleProcess
 import io.github.cdsap.daemonitor.store.WatcherDatabase
@@ -102,6 +103,9 @@ class WatcherRuntime(
             aggregator = BuildAggregator(
                 sampleProvider = database::samplesInWindow,
                 ambientEnvNames = System.getenv().keys.toSet(),
+                logSnippetLimit = with(MonitoringConfig.DEFAULT.logSnippetLimit) {
+                    BuildAggregator.LogSnippetLimit(lines = lines, chars = chars)
+                },
             ),
             database = database,
         )

--- a/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
+++ b/src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.daemonitor.domain
 
-import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.domain.model.Build
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
@@ -29,7 +28,14 @@ class BuildAggregator(
     /** Env-var names in the watcher's own process — subtracted from each build's env before agent
      *  fingerprinting so an ambient agent session is not mis-attributed to every build it spawns. */
     private val ambientEnvNames: Set<String> = emptySet(),
+    private val logSnippetLimit: LogSnippetLimit = DEFAULT_LOG_SNIPPET_LIMIT,
 ) {
+    /** Bounds for in-window build log excerpts retained until a build is emitted. */
+    data class LogSnippetLimit(val lines: Int, val chars: Int)
+
+    companion object {
+        val DEFAULT_LOG_SNIPPET_LIMIT = LogSnippetLimit(lines = 100, chars = 16_000)
+    }
     private val daemons = mutableMapOf<Long, DaemonState>()
 
     fun onEvents(daemonPid: Long, events: List<BuildEvent>): List<Build> {
@@ -58,7 +64,7 @@ class BuildAggregator(
                     state.window?.takeIf { it.qualified }?.let { w ->
                         emitted += w.toBuild(daemonPid, state.uid, endMs = event.timestampMs, sampleProvider, ambientEnvNames)
                     }
-                    state.window = Window(busyTimeMs = event.timestampMs)
+                    state.window = Window(busyTimeMs = event.timestampMs, logSnippetLimit = logSnippetLimit)
                     line?.let { state.window?.appendLogLine(it) }
                 }
 
@@ -110,6 +116,7 @@ class BuildAggregator(
 
     private class Window(
         val busyTimeMs: Long,
+        private val logSnippetLimit: LogSnippetLimit,
         var qualified: Boolean = false,
         var buildId: String? = null,
         var currentDir: String? = null,
@@ -121,11 +128,10 @@ class BuildAggregator(
         private var logChars = 0
 
         fun appendLogLine(line: String) {
-            val snippetLimit = MonitoringConfig.DEFAULT.logSnippetLimit
-            val boundedLine = line.takeLast(snippetLimit.chars)
+            val boundedLine = line.takeLast(logSnippetLimit.chars)
             logLines.addLast(boundedLine)
             logChars += boundedLine.length + if (logLines.size > 1) 1 else 0
-            while (logLines.size > snippetLimit.lines || logChars > snippetLimit.chars) {
+            while (logLines.size > logSnippetLimit.lines || logChars > logSnippetLimit.chars) {
                 val removed = logLines.removeFirst()
                 logChars -= removed.length + if (logLines.isNotEmpty()) 1 else 0
             }

--- a/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
+++ b/src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt
@@ -1,6 +1,5 @@
 package io.github.cdsap.daemonitor.domain
 
-import io.github.cdsap.daemonitor.config.MonitoringConfig
 import io.github.cdsap.daemonitor.domain.model.BuildEnvNames
 import io.github.cdsap.daemonitor.domain.model.BuildEvent
 import io.github.cdsap.daemonitor.domain.model.BuildStart
@@ -99,11 +98,18 @@ class BuildAggregatorTest {
     }
 
     @Test
+    fun `default log snippet limit is 100 lines and 16000 chars`() {
+        val limit = BuildAggregator.DEFAULT_LOG_SNIPPET_LIMIT
+        assertEquals(100, limit.lines)
+        assertEquals(16_000, limit.chars)
+    }
+
+    @Test
     fun `interrupted build retains its bounded in-window log excerpt`() {
-        val agg = BuildAggregator()
+        val snippetLimit = BuildAggregator.LogSnippetLimit(lines = 5, chars = 500)
+        val agg = BuildAggregator(logSnippetLimit = snippetLimit)
         agg.onLogLine(pid, "busy", BusyMark(1_000))
         agg.onLogLine(pid, "start", start(1_010))
-        val snippetLimit = MonitoringConfig.DEFAULT.logSnippetLimit
         repeat(snippetLimit.lines + 5) { index ->
             agg.onLogLine(pid, "line-$index-${"x".repeat(200)}", null)
         }


### PR DESCRIPTION
## Summary

### Problem

`domain/BuildAggregator.kt` imports `config/MonitoringConfig` and reads `MonitoringConfig.DEFAULT.logSnippetLimit` inside the private `Window.appendLogLine()` path (around line 124). That makes core build-correlation logic depend on an application policy module, and domain unit tests (`domain/BuildAggregatorTest.kt`) must import `MonitoringConfig` to assert snippet bounds.

### Why this matters

In a clean/hexagonal layout, the domain layer should not depend on configuration defaults. The current coupling hides a policy knob inside domain code, makes the aggregator harder to test with smaller limits, and works against the repo's own direction of keeping polling/log policy in `MonitoringConfig` while wiring concrete values at the composition root (`AppContainer.kt`).

### Proposed change

Add `logSnippetLimit` (or `logSnippetLines` / `logSnippetChars`) as a constructor parameter on `BuildAggregator`, with domain-local defaults matching today's values (100 lines, 16_000 chars). Remove the `MonitoringConfig` import from `BuildAggregator`. Wire the limit from `MonitoringConfig.DEFAULT.logSnippetLimit` only in composition roots (`AppContainer.kt`, and optionally `WatcherRuntime.create()`). Update `BuildAggregatorTest` to pass an explicit small limit in the bounded-log test instead of referencing `MonitoringConfig`.

### Notes

This is a dependency-inversion fix: `BuildAggregator` owns build-window correlation rules, while retention of log excerpts is a policy concern supplied at the edge. The repo already follows this pattern for poll cadence (`MonitoringConfig.DEFAULT.pollInterval` wired in `AppContainer`, not inside domain code) and for persistence ports (`WatcherDatabase` implements application repositories). A closely related follow-up—not part of this issue—would be pointing `HistoryService` at the existing `persistence.BuildRepository` port instead of `WatcherDatabase`.

Fixes #130

## Changes

- `src/main/kotlin/io/github/cdsap/daemonitor/AppContainer.kt`
- `src/main/kotlin/io/github/cdsap/daemonitor/WatcherRuntime.kt`
- `src/main/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregator.kt`
- `src/test/kotlin/io/github/cdsap/daemonitor/domain/BuildAggregatorTest.kt`

## Verification

- `./gradlew test`
